### PR TITLE
Fix 2 bugs (TypeError deepcopy & ordered set) + format with black

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+*.pyc
+build
+dist
+
+.eggs/*
+beniget.egg-info/*
+
+docs/_build/*
+
+**/.vscode/*


### PR DESCRIPTION
It's not a real PR to be merged. Just to show diff.

It fixes two bugs:

- with IPython, a TypeError was raised during `deepcopy(Buildings)`

- sets are not ordered even in Python 3.6 (https://stackoverflow.com/a/45589769)

Otherwise, I also (automatically) used `black`, which adds many diffs. I guess all C++ developers using clang-format should use black :slightly_smiling_face: 