### PR TITLE
Fix issue defuse chains for annotation of parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.pyc
+
+.eggs
+beniget.egg-info
+
+.pytest_cache
+.vscode

--- a/beniget/beniget.py
+++ b/beniget/beniget.py
@@ -709,6 +709,9 @@ class DefUseChains(ast.NodeVisitor):
                 if dnode not in self.locals[self._currenthead[-1]]:
                     self.locals[self._currenthead[-1]].append(dnode)
 
+            if node.annotation is not None:
+                self.visit(node.annotation)
+
         elif isinstance(node.ctx, ast.Load):
             for d in self.defs(node):
                 d.add_user(dnode)

--- a/tests/chains.py
+++ b/tests/chains.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+from unittest import TestCase, skipIf
 import gast as ast
 import beniget
 import sys
@@ -192,6 +192,11 @@ class TestDefUseChains(TestCase):
     def test_class_decorator(self):
         code = "from some import decorator\n@decorator\nclass C:pass"
         self.checkChains(code, ["decorator -> (decorator -> (C -> ()))", "C -> ()"])
+
+    @skipIf(sys.version_info.major < 3, "Python 3 syntax")
+    def test_class_annotation(self):
+        code = "type_ = int\ndef foo(bar: type_): pass"
+        self.checkChains(code, ['type_ -> (type_ -> ())', 'foo -> ()'])
 
 
 class TestUseDefChains(TestCase):


### PR DESCRIPTION
Fix an issue with:
```
import gast as ast
import beniget

code = "def foo(bar: int): pass"

module = ast.parse(code)
duc = beniget.DefUseChains()
duc.visit(module)

fdef = module.body[0]
name = fdef.args.args[0]

duc.chains[name.annotation]

assert duc.dump_chains(name.annotation) == []
```

Is this fix correct?

Do you want a test for this? Something like ?

```
code = """
type_ = "int"
def foo(bar: type_):
    pass
"""
module = ast.parse(code)
duc = beniget.DefUseChains()
duc.visit(module)
fdef = module.body[1]
name = fdef.args.args[0]
duc.chains[name.annotation]
assert str(duc.chains[module.body[0].targets[0]]) == 'type_ -> (type_ -> ())'
```

I didn't resist to add the .gitignore...

 