### PR TITLE
Convert stars and d[name] to lists

### DIFF
--- a/beniget/beniget.py
+++ b/beniget/beniget.py
@@ -257,7 +257,9 @@ class DefUseChains(ast.NodeVisitor):
         stars = []
         for d in reversed(self._definitions):
             if name in d:
-                return d[name] if not stars else stars + d[name]
+                # have to make sure stars and d[name] are lists otherwise
+                # they can't be concatenated
+                return d[name] if not stars else list(stars) + list(d[name])
             if "*" in d:
                 stars.extend(d["*"])
 


### PR DESCRIPTION
Hey @serge-sans-paille, when I implemented the recursion on memestra I found the following error with one of the python modules it was parsing:

```
File "/home/mariana/.local/lib/python3.8/site-packages/beniget/beniget.py", line 260, in defs                                                              return d[name] if not stars else stars + d[name]                                                                                                          
TypeError: can only concatenate list (not "ordered_set") to list   
```

This fixes it.