### PR TITLE
Expose filename reporting in DefUseChains unbound identifier error reporting

### DIFF
--- a/beniget/beniget.py
+++ b/beniget/beniget.py
@@ -199,7 +199,7 @@ class DefUseChains(ast.NodeVisitor):
         """
         self.chains = {}
         self.locals = defaultdict(list)
-        self.filename = "{}:".format(filename) if filename else ""
+        self.filename = filename
 
         # deep copy of builtins, to remain reentrant
         self._builtins = {k: Def(v) for k, v in Builtins.items()}
@@ -245,7 +245,10 @@ class DefUseChains(ast.NodeVisitor):
 
     def unbound_identifier(self, name, node):
         if hasattr(node, "lineno"):
-            location = " at {}{}:{}".format(self.filename,
+            filename = "{}:".format(
+                "<unknown>" if self.filename is None else self.filename
+            )
+            location = " at {}{}:{}".format(filename,
                                             node.lineno,
                                             node.col_offset)
         else:


### PR DESCRIPTION
I wanted to know where the unbound identifier errors were coming form, and saw that there was already some code to do this for the command-line script, so I just moved it to DefUseChains. I also swapped the order in the message to `filename:lineno:coloffset` (instead of `lineno:coloffset:filename`) because this is supported by some editors to open a file directly at a specific line and column.