### PR TITLE
Add support for NamedExpr nodes

### DIFF
--- a/beniget/beniget.py
+++ b/beniget/beniget.py
@@ -851,8 +851,8 @@ class DefUseChains(ast.NodeVisitor):
 
     def visit_NamedExpr(self, node):
         dnode = self.chains.setdefault(node, Def(node))
-        self.visit(node.target)
         self.visit(node.value).add_user(dnode)
+        self.visit(node.target)
         return dnode
 
     def visit_Name(self, node):

--- a/beniget/beniget.py
+++ b/beniget/beniget.py
@@ -849,6 +849,12 @@ class DefUseChains(ast.NodeVisitor):
 
     visit_Starred = visit_Await
 
+    def visit_NamedExpr(self, node):
+        dnode = self.chains.setdefault(node, Def(node))
+        self.visit(node.target)
+        self.visit(node.value).add_user(dnode)
+        return dnode
+
     def visit_Name(self, node):
 
         if isinstance(node.ctx, (ast.Param, ast.Store)):

--- a/tests/chains.py
+++ b/tests/chains.py
@@ -384,16 +384,33 @@ cos = pop()'''
             'cos -> (cos -> (Call -> ()))'
         ])
 
-    @skipIf(sys.version_info < (3, 8), "Python 3.8 syntax")
-    def test_named_expr(self):
+    @skipIf(sys.version_info < (3, 8), 'Python 3.8 syntax')
+    def test_named_expr_simple(self):
+        code = '''
+if (x := 1):
+    y = x + 1'''
+        self.checkChains(
+            code, ['x -> (x -> (BinOp -> ()))', 'y -> ()']
+        )
+
+    @skipIf(sys.version_info < (3, 8), 'Python 3.8 syntax')
+    def test_named_expr_complex(self):
         code = '''
 if (x := (y := 1) + 1):
     z = x + y'''
-        self.checkChains(code, [
-            'x -> (x -> (BinOp -> ()))',
-            'y -> (y -> (BinOp -> ()))',
-            'z -> ()'
-        ])
+        self.checkChains(
+            code, ['y -> (y -> (BinOp -> ()))', 'x -> (x -> (BinOp -> ()))', 'z -> ()']
+        )
+
+    @skipIf(sys.version_info < (3, 8), 'Python 3.8 syntax')
+    def test_named_expr_with_rename(self):
+        code = '''
+a = 1
+if (a := a + a):
+    pass'''
+        self.checkChains(
+            code, ['a -> (a -> (BinOp -> (NamedExpr -> ())), a -> (BinOp -> (NamedExpr -> ())))', 'a -> ()']
+        )
 
 
 class TestUseDefChains(TestCase):

--- a/tests/chains.py
+++ b/tests/chains.py
@@ -384,6 +384,16 @@ cos = pop()'''
             'cos -> (cos -> (Call -> ()))'
         ])
 
+    def test_named_expr(self):
+        code = '''
+if (x := (y := 1) + 1):
+    z = x + y'''
+        self.checkChains(code, [
+            'x -> (x -> (BinOp -> ()))',
+            'y -> (y -> (BinOp -> ()))',
+            'z -> ()'
+        ])
+
 
 class TestUseDefChains(TestCase):
     def checkChains(self, code, ref):

--- a/tests/chains.py
+++ b/tests/chains.py
@@ -384,6 +384,7 @@ cos = pop()'''
             'cos -> (cos -> (Call -> ()))'
         ])
 
+    @skipIf(sys.version_info < (3, 8), "Python 3.8 syntax")
     def test_named_expr(self):
         code = '''
 if (x := (y := 1) + 1):


### PR DESCRIPTION
This PR adds support for NamedExpr nodes

Unit tests are included.

One thing I'm not entirely sure of is whether a `NamedExpr`
node should be considered a user of its target.

`NamedExpr`s do evaluate to the value of the thing they are storing, so it seems
like one could make the argument that they are in fact a user of the name they
are defining.

Happy to discuss what to do about that.
