### PR TITLE
Fix handling of wildcard imports

### DIFF
--- a/beniget/beniget.py
+++ b/beniget/beniget.py
@@ -833,7 +833,10 @@ class DefUseChains(ast.NodeVisitor):
     def visit_ImportFrom(self, node):
         for alias in node.names:
             dalias = self.chains.setdefault(alias, Def(alias))
-            self.set_definition(alias.asname or alias.name, dalias)
+            if alias.name == '*':
+                self.extend_definition('*', dalias)
+            else:
+                self.set_definition(alias.asname or alias.name, dalias)
             self.locals[self._scopes[-1]].append(dalias)
 
     def visit_Exec(self, node):

--- a/tests/chains.py
+++ b/tests/chains.py
@@ -600,6 +600,18 @@ if (a := a + a):
         self.checkChains(
             code, ['a -> (a -> (BinOp -> (NamedExpr -> ())), a -> (BinOp -> (NamedExpr -> ())))', 'a -> ()']
         )
+    
+    def test_import_dotted_name_binds_first_name(self):
+        code = '''import collections.abc;collections;collections.abc'''
+        self.checkChains(
+            code, ['collections -> (collections -> (), collections -> (Attribute -> ()))']
+        )
+
+    def test_multiple_wildcards_may_bind(self):
+        code = '''from abc import *; from collections import *;name1; from mod import *;name2'''
+        self.checkChains(
+            code, ['* -> (name1 -> (), name2 -> ())','* -> (name1 -> (), name2 -> ())','* -> (name2 -> ())']
+        )
 
 
 class TestUseDefChains(TestCase):

--- a/tests/chains.py
+++ b/tests/chains.py
@@ -612,6 +612,14 @@ if (a := a + a):
         self.checkChains(
             code, ['* -> (name1 -> (), name2 -> ())','* -> (name1 -> (), name2 -> ())','* -> (name2 -> ())']
         )
+    
+    def test_wildcard_may_override(self):
+        # we could argue that the wildcard import might override name2,
+        # but we're currently ignoring these kind of scenarios.
+        code = '''name2=True;from abc import *;name2'''
+        self.checkChains(
+            code, ['name2 -> (name2 -> ())', '* -> ()']
+        )
 
 
 class TestUseDefChains(TestCase):


### PR DESCRIPTION
When we hit a wildcard import, the wildcard def is added to the definitions of "*" and does not replace it anymore. This change ensure that beniget produces an over-approximation of the code and not an under-approximation.