### PR TITLE
Fix bug in warlus operator

### DIFF
--- a/beniget/beniget.py
+++ b/beniget/beniget.py
@@ -1302,7 +1302,7 @@ def _validate_comprehension(node):
         bound = getattr(name.target, 'id', None)
         if bound in iter_names:
             raise SyntaxError('assignment expression cannot rebind '
-                             f'comprehension iteration variable {bound!r}')
+                              "comprehension iteration variable '{}'".format(bound))
 
 def _iter_arguments(args):
     """

--- a/beniget/beniget.py
+++ b/beniget/beniget.py
@@ -1286,27 +1286,15 @@ def _validate_comprehension(node):
      - a named expression is used in a comprehension iterable expression
      - a named expression rebinds a comprehension iteration variable
     """
-    # build the iterator used to find named expressions, 
-    # for performance, we're not using ast.walk(node), because we
-    # are already checking the generators[].iter field separately.
-    if isinstance(node, ast.DictComp):
-        iterator = iterchain(ast.walk(node.key), ast.walk(node.value))
-    else:
-        iterator = ast.walk(node.elt)
     iter_names = set() # comprehension iteration variables
     for gen in node.generators:
-        for name in (n for n in ast.walk(gen.iter) 
-                     if isinstance(n, ast.NamedExpr)):
+        for namedexpr in (n for n in ast.walk(gen.iter) if isinstance(n, ast.NamedExpr)):
             raise SyntaxError('assignment expression cannot be used '
                                 'in a comprehension iterable expression')
         iter_names.update(n.id for n in ast.walk(gen.target) 
             if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Store))
-        for i in gen.ifs:
-            iterator = iterchain(iterator, ast.walk(i))
-        iterator = iterchain(iterator, ast.walk(gen.target))
-    named_expr_iter = (n for n in iterator if  isinstance(n, ast.NamedExpr))
-    for name in named_expr_iter:
-        bound = getattr(name.target, 'id', None)
+    for namedexpr in (n for n in ast.walk(node) if  isinstance(n, ast.NamedExpr)):
+        bound = getattr(namedexpr.target, 'id', None)
         if bound in iter_names:
             raise SyntaxError('assignment expression cannot rebind '
                               "comprehension iteration variable '{}'".format(bound))

--- a/beniget/beniget.py
+++ b/beniget/beniget.py
@@ -1,6 +1,5 @@
 from collections import defaultdict, OrderedDict
 from contextlib import contextmanager
-from itertools import chain as iterchain
 import sys
 
 import gast as ast

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -643,7 +643,7 @@ if (a := a + a):
         # for-target name appearing in any comprehension containing the assignment expression.
         # A further exception applies when an assignment expression occurs in a comprehension whose 
         # containing scope is a class scope. If the rules above were to result in the target 
-        # being assigned in that class’s scope, the assignment expression is expressly invalid.
+        # being assigned in that class's scope, the assignment expression is expressly invalid.
         code = '''
 stuff = []
 


### PR DESCRIPTION
Store warlus target in first non-comprehension scope and properly validate all compréhensions before analyzing them so beniget does not draw incorrect conclusion about variable existing when it raises SyntaxError at runtime.

Fixes #61.