### PR TITLE
Fix islive flag when there are conditional branches

### DIFF
--- a/beniget/beniget.py
+++ b/beniget/beniget.py
@@ -632,19 +632,17 @@ class DefUseChains(ast.NodeVisitor):
 
         # set the islive flag to False on killed Defs
         for d in self._definitions[-1].get(name, ()):
-            if not isinstance(d.node, ast.AST) or d in dnodes:
-                # A builtin or a redundant call to set_definition(),
-                # this happens when we merge definitions from different branches
-                # of a 'if' statement for instance. 
-                # We never explicitely mark the builtins as killed, since 
+            if not isinstance(d.node, ast.AST):
+                # A builtin: we never explicitely mark the builtins as killed, since 
                 # it can be easily deducted.
                 continue
-
-            if any(d in definitions.get(name, ()) for definitions in self._definitions[:-1]):
-                # The definition exists in an enclosing definition context, so we can't
-                # be sure wether it's killed or not
+            if d in dnodes or any(d in definitions.get(name, ()) for 
+                   definitions in self._definitions[:-1]):
+                # The definition exists in another definition context, so we can't
+                # be sure wether it's killed or not, this happens when:
+                # - a variable is conditionnaly declared (d in dnodes)
+                # - a variable is conditionnaly killed (any(...))
                 continue
-            
             d.islive = False
         
         self._definitions[-1][name] = dnodes

--- a/beniget/beniget.py
+++ b/beniget/beniget.py
@@ -639,6 +639,11 @@ class DefUseChains(ast.NodeVisitor):
                 # We never explicitely mark the builtins as killed, since 
                 # it can be easily deducted.
                 continue
+
+            if any(d in definitions.get(name, ()) for definitions in self._definitions[:-1]):
+                # The definition exists in an enclosing definition context, so we can't
+                # be sure wether it's killed or not
+                continue
             
             d.islive = False
         

--- a/beniget/beniget.py
+++ b/beniget/beniget.py
@@ -633,13 +633,13 @@ class DefUseChains(ast.NodeVisitor):
             dnodes = ordered_set(dnode_or_dnodes)
 
         # set the islive flag to False on killed Defs
-        for d in self._definitions[-1].get(name, ()):
+        for d in self._definitions[index].get(name, ()):
             if not isinstance(d.node, ast.AST):
                 # A builtin: we never explicitely mark the builtins as killed, since 
                 # it can be easily deducted.
                 continue
             if d in dnodes or any(d in definitions.get(name, ()) for 
-                   definitions in self._definitions[:-1]):
+                   definitions in self._definitions[:index]):
                 # The definition exists in another definition context, so we can't
                 # be sure wether it's killed or not, this happens when:
                 # - a variable is conditionnaly declared (d in dnodes)
@@ -647,7 +647,7 @@ class DefUseChains(ast.NodeVisitor):
                 continue
             d.islive = False
         
-        self._definitions[-1][name] = dnodes
+        self._definitions[index][name] = dnodes
 
     @staticmethod
     def add_to_definition(definition, name, dnode_or_dnodes):

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -471,7 +471,7 @@ class TestDefIsLive(TestCase):
                 @property
                 def exceptions(self) -> tuple: ...
         '''
-        if sys.version_info>=3.10:
+        if sys.version_info>=(3,10):
             self.checkLiveLocals(code, ['sys:2', 'property:3', 'ExceptionGroup:5'], 
                                 ['sys:2', 'property:3', 'ExceptionGroup:5'])
         else:

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -474,7 +474,7 @@ class TestDefIsLive(TestCase):
         if sys.version_info>=(3,10):
             self.checkLiveLocals(code, ["sys:2", "_PY37PLUS:4,6"], ["sys:2", "_PY37PLUS:4,6"])
         else:
-            self.checkLiveLocals(code, ["sys:None", "_PY37PLUS:4,6"], ["sys:2", "_PY37PLUS:4,6"])
+            self.checkLiveLocals(code, ["sys:None", "_PY37PLUS:4,6"], ["sys:None", "_PY37PLUS:4,6"])
     
     def test_BuiltinNameRedefConditional(self):
         code = '''

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -465,11 +465,13 @@ class TestDefIsLive(TestCase):
     def test_BuiltinNameRedefConditional(self):
         code = '''
         import sys
-        class property:...
+        class property:
+            pass
         if sys.version_info >= (3, 11):
             class ExceptionGroup(Exception):
                 @property
-                def exceptions(self) -> tuple: ...
+                def exceptions(self) -> tuple:
+                    pass
         '''
         if sys.version_info>=(3,10):
             self.checkLiveLocals(code, ['sys:2', 'property:3', 'ExceptionGroup:5'], 

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -498,7 +498,7 @@ class TestDefIsLive(TestCase):
             node, c = self.checkLiveLocals(code, ['x:2'], ['x:2'])
             self.checkLocals(c, node.body[-1].value, ['x:3'], only_live=True)
         else:
-            self.checkLiveLocals(code, ['x:2,3'], ['x:3'])
+            self.checkLiveLocals(code, ['x:2,3'], ['x:2,3'])
 
 
     def test_var_redef_in_method_scope(self):

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -494,8 +494,12 @@ class TestDefIsLive(TestCase):
         x = True
         [x for x in (1,2)]
         '''
-        node, c = self.checkLiveLocals(code, ['x:2'], ['x:2'])
-        self.checkLocals(c, node.body[-1].value, ['x:3'], only_live=True)
+        if sys.version_info > (3,):
+            node, c = self.checkLiveLocals(code, ['x:2'], ['x:2'])
+            self.checkLocals(c, node.body[-1].value, ['x:3'], only_live=True)
+        else:
+            self.checkLiveLocals(code, ['x:2,3'], ['x:3'])
+
 
     def test_var_redef_in_method_scope(self):
         code = '''\

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -498,7 +498,7 @@ class TestDefIsLive(TestCase):
             node, c = self.checkLiveLocals(code, ['x:2'], ['x:2'])
             self.checkLocals(c, node.body[-1].value, ['x:3'], only_live=True)
         else:
-            self.checkLiveLocals(code, ['x:2,3'], ['x:2,3'])
+            self.checkLiveLocals(code, ['x:2,3'], ['x:3'])
 
 
     def test_var_redef_in_method_scope(self):

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -470,7 +470,7 @@ class TestDefIsLive(TestCase):
         if sys.version_info >= (3, 11):
             class ExceptionGroup(Exception):
                 @property
-                def exceptions(self) -> tuple:
+                def exceptions(self):
                     pass
         '''
         if sys.version_info>=(3,10):

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -498,7 +498,7 @@ class TestDefIsLive(TestCase):
             node, c = self.checkLiveLocals(code, ['x:2'], ['x:2'])
             self.checkLocals(c, node.body[-1].value, ['x:3'], only_live=True)
         else:
-            self.checkLiveLocals(code, ['x:2,3'], ['x:3'])
+            self.checkLiveLocals(code, ['x:3'], ['x:2,3'])
 
 
     def test_var_redef_in_method_scope(self):

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -471,5 +471,9 @@ class TestDefIsLive(TestCase):
                 @property
                 def exceptions(self) -> tuple: ...
         '''
-        self.checkLiveLocals(code, ['sys:2', 'property:3', 'ExceptionGroup:5'], 
-                             ['sys:2', 'property:3', 'ExceptionGroup:5'])
+        if sys.version_info>=3.10:
+            self.checkLiveLocals(code, ['sys:2', 'property:3', 'ExceptionGroup:5'], 
+                                ['sys:2', 'property:3', 'ExceptionGroup:5'])
+        else:
+            self.checkLiveLocals(code, ['sys:None', 'property:3', 'ExceptionGroup:5'], 
+                                ['sys:None', 'property:3', 'ExceptionGroup:5'])

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -405,7 +405,7 @@ class TestDefIsLive(TestCase):
         c.visit(node)
 
         def checkDefs(dumped, ref):
-            self.assertEqual(dumped, ref)
+            self.assertEqual(dumped.sort(), ref.sort())
 
         checkDefs(c._dump_locals(node, only_live=True), livelocals)
         checkDefs(c._dump_locals(node), locals)

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -462,6 +462,19 @@ class TestDefIsLive(TestCase):
             a = a + 1
             """
         self.checkLiveLocals(code, ["a:4"], ["a:2,3,4"])
+
+    def test_BothLive(self):
+        code = '''
+        import sys
+        if sys.version_info >= (3, 7, 0):
+            _PY37PLUS = True
+        else:
+            _PY37PLUS = False
+        '''
+        if sys.version_info>=(3,10):
+            self.checkLiveLocals(code, ["sys:2", "_PY37PLUS:4,6"], ["sys:2", "_PY37PLUS:4,6"])
+        else:
+            self.checkLiveLocals(code, ["sys:None", "_PY37PLUS:4,6"], ["sys:2", "_PY37PLUS:4,6"])
     
     def test_BuiltinNameRedefConditional(self):
         code = '''

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -405,7 +405,7 @@ class TestDefIsLive(TestCase):
         c.visit(node)
 
         def checkDefs(dumped, ref):
-            self.assertEqual(dumped.sort(), ref.sort())
+            self.assertEqual(sorted(dumped), sorted(ref))
 
         checkDefs(c._dump_locals(node, only_live=True), livelocals)
         checkDefs(c._dump_locals(node), locals)

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -474,8 +474,8 @@ class TestDefIsLive(TestCase):
                     pass
         '''
         if sys.version_info>=(3,10):
-            self.checkLiveLocals(code, ['sys:2', 'property:3', 'ExceptionGroup:5'], 
-                                ['sys:2', 'property:3', 'ExceptionGroup:5'])
+            self.checkLiveLocals(code, ['sys:2', 'property:3', 'ExceptionGroup:6'], 
+                                ['sys:2', 'property:3', 'ExceptionGroup:6'])
         else:
-            self.checkLiveLocals(code, ['sys:None', 'property:3', 'ExceptionGroup:5'], 
-                                ['sys:None', 'property:3', 'ExceptionGroup:5'])
+            self.checkLiveLocals(code, ['sys:None', 'property:3', 'ExceptionGroup:6'], 
+                                ['sys:None', 'property:3', 'ExceptionGroup:6'])


### PR DESCRIPTION
There is an issue with the current logic, it doesn't account for definition that already exists and marks it killed by itself when there are conditional control-flow statements like if blocks... :/ 