### PR TITLE
Better support for starred destructuring

### DIFF
--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -75,6 +75,11 @@ class TestDefUseChains(TestCase):
         code = "for a, b in ((1,2), (3,4)): a"
         self.checkChains(code, ["a -> (a -> ())", "b -> ()"])
 
+    if sys.version_info.major >= 3:
+        def test_type_destructuring_starred(self):
+            code = "a, *b = range(2); b"
+            self.checkChains(code, ['a -> ()', 'b -> (b -> ())'])
+
     def test_assign_in_loop(self):
         code = "a = 2\nwhile 1: a = 1\na"
         self.checkChains(code, ["a -> (a -> ())", "a -> (a -> ())"])

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -89,6 +89,11 @@ class TestGlobals(TestCase):
         code = "x, y = 1, 2"
         self.checkGlobals(code, ["x", "y"])
 
+    if sys.version_info.major >= 3:
+        def testGlobalStarredDestructuring(self):
+            code = "x, *y = 1, [2]"
+            self.checkGlobals(code, ["x", "y"])
+
     def testGlobalAugAssign(self):
         code = "x = 1; x += 2"
         self.checkGlobals(code, ["x"])
@@ -368,6 +373,10 @@ class TestLocals(TestCase):
                 "def foo():\n def bar():\n  nonlocal a; a = 1\n a = 2; bar(); return a"
             )
             self.checkLocals(code, ["a", "bar"])
+
+        def test_LocalDestructuring(self):
+            code = "def foo(x): y, *z = x"
+            self.checkLocals(code, ["x", "y", "z"])
 
     def test_LocalMadeGlobal(self):
         code = "def foo(): global a; a = 1"


### PR DESCRIPTION
Previously, x, *y = z was not adding y in the locals / globals