### PR TITLE
Fix AnnAssign

### DIFF
--- a/beniget/beniget.py
+++ b/beniget/beniget.py
@@ -779,14 +779,11 @@ class DefUseChains(ast.NodeVisitor):
         if node.value:
             dvalue = self.visit(node.value)
         if not self.future_annotations:
-            dannotation = self.visit(node.annotation)
+            self.visit(node.annotation)
         else:
             self._defered_annotations[-1].append(
-                (node.annotation, list(self._scopes),
-                lambda d:dtarget.add_user(d)))
+                (node.annotation, list(self._scopes), None))
         dtarget = self.visit(node.target)
-        if not self.future_annotations:
-            dtarget.add_user(dannotation)
         if node.value:
             dvalue.add_user(dtarget)
 

--- a/beniget/beniget.py
+++ b/beniget/beniget.py
@@ -777,15 +777,13 @@ class DefUseChains(ast.NodeVisitor):
 
     def visit_AnnAssign(self, node):
         if node.value:
-            dvalue = self.visit(node.value)
+            self.visit(node.value)
         if not self.future_annotations:
             self.visit(node.annotation)
         else:
             self._defered_annotations[-1].append(
                 (node.annotation, list(self._scopes), None))
-        dtarget = self.visit(node.target)
-        if node.value:
-            dvalue.add_user(dtarget)
+        self.visit(node.target)
 
     def visit_AugAssign(self, node):
         dvalue = self.visit(node.value)

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -935,7 +935,7 @@ Thing:TypeAlias = 'Mapping'
                     'Type -> (Type -> (Subscript -> ()))',
                     'C -> (C -> (Attribute -> ()), C -> (Attribute -> ()), C -> (Attribute -> '
                     '(Attribute -> ())))',
-                    'Thing -> (Thing -> (), Thing -> (Subscript -> ()), TypeAlias -> ())'], 
+                    'Thing -> (Thing -> (), Thing -> (Subscript -> ()))'], 
                 strict=False
             )
         produced_messages = out.getvalue().strip().split("\n")
@@ -954,12 +954,12 @@ Thing:TypeAlias = 'Mapping'
                             'method -> ()',
                             'method -> ()',
                             'method -> ()',
-                            'field -> (field -> (), field -> (), TypeAlias -> ())',
+                            'field -> (field -> (), field -> ())',
                             'D -> (D -> ())'])
         
         # locals of D
         self.assertEqual(c.dump_chains(node.body[-2].body[-1]), 
-                         ['field2 -> (TypeAlias -> (), field2 -> (), field2 -> ())',
+                         ['field2 -> (field2 -> (), field2 -> ())',
                             'method -> ()',
                             'method -> ()',
                             'method -> ()',
@@ -1010,13 +1010,13 @@ primes: List[int] # should resolve to the star
 
         self.checkChains(
                 code, 
-                ['* -> (List -> (Subscript -> ()))', 'primes -> (Subscript -> ())'],
+                ['* -> (List -> (Subscript -> ()))', 'primes -> ()'],
                 strict=False
             )
         # same with 'from __future__ import annotations'
         self.checkChains(
                 'from __future__ import annotations\n' + code, 
-                ['annotations -> ()', '* -> (List -> (Subscript -> ()))', 'primes -> (Subscript -> ())'],
+                ['annotations -> ()', '* -> (List -> (Subscript -> ()))', 'primes -> ()'],
                 strict=False
             )
     
@@ -1036,7 +1036,7 @@ List = list
                 code, 
                 ['annotations -> ()',
                 '* -> ()',
-                'primes -> (Subscript -> ())',
+                'primes -> ()',
                 'List -> (List -> (Subscript -> ()))'],
                 strict=False
             )
@@ -1270,6 +1270,12 @@ A = bytes
                  'A -> (A -> (), A -> ())'], # good
                 strict=False
             )
+    
+    @skipIf(sys.version_info.major < 3, "Python 3 syntax")
+    def test_annotation_def_is_not_assign_target(self):
+        code = 'from typing import Optional; var:Optional'
+        self.checkChains(code, ['Optional -> (Optional -> ())', 
+                                'var -> ()'])
         
 class TestUseDefChains(TestCase):
     def checkChains(self, code, ref):


### PR DESCRIPTION
Fixes #63. Treat more like `Assign`.