### PR TITLE
Change naming scheme of Def.name() for nodes without a name.

### DIFF
--- a/beniget/beniget.py
+++ b/beniget/beniget.py
@@ -118,7 +118,7 @@ class Def(object):
         elif isinstance(self.node, tuple):
             return self.node[1]
 
-        return type(self.node).__name__
+        return f'<{type(self.node).__name__.lower()}>'
 
     def users(self):
         """
@@ -274,7 +274,7 @@ class DefUseChains(ast.NodeVisitor):
     d: 0
     >>> alias_def = duc.chains[module.body[0].names[0]]
     >>> print(alias_def)
-    c -> (c -> (Call -> ()))
+    c -> (c -> (<call> -> ()))
 
     One instance of DefUseChains is only suitable to analyse one AST Module in it's lifecycle.
     """
@@ -1453,7 +1453,7 @@ def lookup_annotation_name_defs(name, heads, locals_map):
     >>> print(lookup_annotation_name_defs('t', heads, duc.locals)[0])
     t -> ()
     >>> print(lookup_annotation_name_defs('c', heads, duc.locals)[0])
-    c -> (c -> (Attribute -> (Call -> ())))
+    c -> (c -> (<attribute> -> (<call> -> ())))
     >>> print(lookup_annotation_name_defs('C', heads, duc.locals)[0])
     C -> ()
     """

--- a/beniget/beniget.py
+++ b/beniget/beniget.py
@@ -118,7 +118,7 @@ class Def(object):
         elif isinstance(self.node, tuple):
             return self.node[1]
 
-        return f'<{type(self.node).__name__.lower()}>'
+        return f'<{type(self.node).__name__}>'
 
     def users(self):
         """
@@ -274,7 +274,7 @@ class DefUseChains(ast.NodeVisitor):
     d: 0
     >>> alias_def = duc.chains[module.body[0].names[0]]
     >>> print(alias_def)
-    c -> (c -> (<call> -> ()))
+    c -> (c -> (<Call> -> ()))
 
     One instance of DefUseChains is only suitable to analyse one AST Module in it's lifecycle.
     """
@@ -1453,7 +1453,7 @@ def lookup_annotation_name_defs(name, heads, locals_map):
     >>> print(lookup_annotation_name_defs('t', heads, duc.locals)[0])
     t -> ()
     >>> print(lookup_annotation_name_defs('c', heads, duc.locals)[0])
-    c -> (c -> (<attribute> -> (<call> -> ())))
+    c -> (c -> (<Attribute> -> (<Call> -> ())))
     >>> print(lookup_annotation_name_defs('C', heads, duc.locals)[0])
     C -> ()
     """

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -43,11 +43,11 @@ class TestDefUseChains(TestCase):
 
     def test_simple_expression(self):
         code = "a = 1; a + 2"
-        self.checkChains(code, ["a -> (a -> (BinOp -> ()))"])
+        self.checkChains(code, ["a -> (a -> (<binop> -> ()))"])
 
     def test_expression_chain(self):
         code = "a = 1; (- a + 2) > 0"
-        self.checkChains(code, ["a -> (a -> (UnaryOp -> (BinOp -> (Compare -> ()))))"])
+        self.checkChains(code, ["a -> (a -> (<unaryop> -> (<binop> -> (<compare> -> ()))))"])
 
     def test_ifexp_chain(self):
         code = "a = 1; a + 1 if a else - a"
@@ -55,9 +55,9 @@ class TestDefUseChains(TestCase):
             code,
             [
                 "a -> ("
-                "a -> (IfExp -> ()), "
-                "a -> (BinOp -> (IfExp -> ())), "
-                "a -> (UnaryOp -> (IfExp -> ()))"
+                "a -> (<ifexp> -> ()), "
+                "a -> (<binop> -> (<ifexp> -> ())), "
+                "a -> (<unaryop> -> (<ifexp> -> ()))"
                 ")"
             ],
         )
@@ -85,7 +85,7 @@ class TestDefUseChains(TestCase):
     def test_reassign_in_loop(self):
         code = "m = 1\nfor i in [1, 2]:\n m = m + 1"
         self.checkChains(
-            code, ["m -> (m -> (BinOp -> ()))", "i -> ()", "m -> (m -> (BinOp -> ()))"]
+            code, ["m -> (m -> (<binop> -> ()))", "i -> ()", "m -> (m -> (<binop> -> ()))"]
         )
 
     def test_continue_in_loop(self):
@@ -115,7 +115,7 @@ class TestDefUseChains(TestCase):
 
     def test_expanded_augassign(self):
         code = "a = 1; a = a + 2"
-        self.checkChains(code, ["a -> (a -> (BinOp -> ()))", "a -> ()"])
+        self.checkChains(code, ["a -> (a -> (<binop> -> ()))", "a -> ()"])
 
     def test_augassign_in_loop(self):
         code = "a = 1\nfor i in [1]:\n a += 2\na"
@@ -145,12 +145,12 @@ for _ in [1]:
 
     def test_simple_print(self):
         code = "a = 1; print(a)"
-        self.checkChains(code, ["a -> (a -> (Call -> ()))"])
+        self.checkChains(code, ["a -> (a -> (<call> -> ()))"])
 
     def test_simple_redefinition(self):
         code = "a = 1; a + 2; a = 3; +a"
         self.checkChains(
-            code, ["a -> (a -> (BinOp -> ()))", "a -> (a -> (UnaryOp -> ()))"]
+            code, ["a -> (a -> (<binop> -> ()))", "a -> (a -> (<unaryop> -> ()))"]
         )
 
     def test_simple_for(self):
@@ -190,7 +190,7 @@ for _ in [1]:
             code,
             ['I -> (I -> ())',
              'J -> (J -> ())',
-             'i -> (i -> (Compare -> ()), i -> ())',
+             'i -> (i -> (<compare> -> ()), i -> ())',
              'I -> (I -> ())',
              'J -> (J -> ())']
         )
@@ -201,9 +201,9 @@ for _ in [1]:
             code,
             [
                 # first assign, out of loop
-                "i -> (i -> (), i -> (BinOp -> ()), i -> ())",
+                "i -> (i -> (), i -> (<binop> -> ()), i -> ())",
                 # second assign, in loop
-                "i -> (i -> (), i -> (BinOp -> ()), i -> ())",
+                "i -> (i -> (), i -> (<binop> -> ()), i -> ())",
             ],
         )
 
@@ -263,7 +263,7 @@ while done:
             [
                 "I -> (I -> ())",
                 "J -> (J -> ())",
-                "i -> (i -> (), i -> (Compare -> ()), i -> ())",
+                "i -> (i -> (), i -> (<compare> -> ()), i -> ())",
                 "J -> (J -> ())",
                 "I -> (I -> ())",
             ],
@@ -331,7 +331,7 @@ while done:
 
     def test_simple_import_as(self):
         code = "import x as y; y()"
-        self.checkChains(code, ["y -> (y -> (Call -> ()))"])
+        self.checkChains(code, ["y -> (y -> (<call> -> ()))"])
     
     def test_simple_lambda(self):
         node, c = self.checkChains( "lambda y: True", [])
@@ -339,23 +339,23 @@ while done:
     
     def test_lambda_defaults(self):
         node, c = self.checkChains( "x=y=1;(lambda y, x=x: (True, x, y, z)); x=y=z=2", 
-                                   ['x -> (x -> (Lambda -> ()))',
+                                   ['x -> (x -> (<lambda> -> ()))',
                                     'y -> ()', 
                                     'x -> ()', 
                                     'y -> ()',
-                                    'z -> (z -> (Tuple -> (Lambda -> ())))']) 
+                                    'z -> (z -> (<tuple> -> (<lambda> -> ())))']) 
         self.assertEqual(c.dump_chains(node.body[1].value), [
-            'y -> (y -> (Tuple -> (Lambda -> ())))',
-            'x -> (x -> (Tuple -> (Lambda -> ())))',
+            'y -> (y -> (Tuple -> (<lambda> -> ())))',
+            'x -> (x -> (Tuple -> (<lambda> -> ())))',
         ])
 
     def test_lambda_varargs(self):
         node, c = self.checkChains( "lambda *args: args", [])
-        self.assertEqual(c.dump_chains(node.body[0].value), ['args -> (args -> (Lambda -> ()))'])
+        self.assertEqual(c.dump_chains(node.body[0].value), ['args -> (args -> (<lambda> -> ()))'])
     
     def test_lambda_kwargs(self):
         node, c = self.checkChains( "lambda **kwargs: kwargs", [])
-        self.assertEqual(c.dump_chains(node.body[0].value), ['kwargs -> (kwargs -> (Lambda -> ()))'])
+        self.assertEqual(c.dump_chains(node.body[0].value), ['kwargs -> (kwargs -> (<lambda> -> ()))'])
 
     def test_multiple_import_as(self):
         code = "import x as y, z; y"
@@ -375,7 +375,7 @@ while done:
 
     def test_method_function_conflict(self):
         code = "def foo():pass\nclass C:\n def foo(self): foo()"
-        self.checkChains(code, ["foo -> (foo -> (Call -> ()))", "C -> ()"])
+        self.checkChains(code, ["foo -> (foo -> (<call> -> ()))", "C -> ()"])
 
     def test_nested_if(self):
         code = "f = 1\nif 1:\n if 1:pass\n else: f=1\nelse: f = 1\nf"
@@ -392,7 +392,7 @@ while done:
     def test_attr(self):
         code = "import numpy as bar\ndef foo():\n return bar.zeros(2)"
         self.checkChains(
-            code, ["bar -> (bar -> (Attribute -> (Call -> ())))", "foo -> ()"]
+            code, ["bar -> (bar -> (<attribute> -> (<call> -> ())))", "foo -> ()"]
         )
 
     def test_class_decorator(self):
@@ -473,7 +473,7 @@ def outer():
         c = beniget.DefUseChains()
         node = ast.parse(code)
         c.visit(node)
-        self.assertEqual(c.dump_chains(node.body[0].body[0]), ['mytype -> (mytype -> (Call -> ()))'])
+        self.assertEqual(c.dump_chains(node.body[0].body[0]), ['mytype -> (mytype -> (<call> -> ()))'])
 
     def check_message(self, code, expected_messages, filename=None):
         node = ast.parse(code)
@@ -574,7 +574,7 @@ while curr:
     else:
         break
 '''
-        self.checkChains(code, ['curr -> (curr -> (), curr -> (Call -> ()))', 
+        self.checkChains(code, ['curr -> (curr -> (), curr -> (<call> -> ()))', 
                                 'parts -> (parts -> (), parts -> ())']*2)
     
     def test_star_assignment_nested(self):
@@ -587,13 +587,13 @@ while curr:
     else:
         break
 '''
-        self.checkChains(code, ['curr -> (curr -> (), curr -> (Call -> ()))',
-                                'parts -> (parts -> (), parts -> (Tuple -> ()))',
-                                'i -> (i -> (Tuple -> ()))']*2)
+        self.checkChains(code, ['curr -> (curr -> (), curr -> (<call> -> ()))',
+                                'parts -> (parts -> (), parts -> (<tuple> -> ()))',
+                                'i -> (i -> (<tuple> -> ()))']*2)
     
     def test_attribute_assignment(self):
         code = "d=object();d.name,x = 't',1"
-        self.checkChains(code, ['d -> (d -> (Attribute -> ()))',
+        self.checkChains(code, ['d -> (d -> (<attribute> -> ()))',
                                 'x -> ()'])
 
     def test_call_assignment(self):
@@ -614,7 +614,7 @@ class Visitor:
         c.visit(node)
         self.assertEqual(c.dump_chains(node),
                          ['Thing -> ()',
-                          'f -> (f -> (Call -> ()))',
+                          'f -> (f -> (<call> -> ()))',
                           'Visitor -> ()'])
         self.assertEqual(c.dump_chains(node.body[-1]),
                          ['Thing -> (Thing -> ())',
@@ -650,9 +650,9 @@ if 1:
         cos()
 cos = pop()'''
         self.checkChains(code, [
-            '* -> (cos -> (Call -> ()))',
-            'pop -> (pop -> (Call -> ()))',
-            'cos -> (cos -> (Call -> ()))'
+            '* -> (cos -> (<call> -> ()))',
+            'pop -> (pop -> (<call> -> ()))',
+            'cos -> (cos -> (<call> -> ()))'
         ])
     
     def test_class_scope_comprehension(self):
@@ -667,10 +667,10 @@ class Cls:
         node, chains = self.checkChains(code, ['Cls -> ()'])
         self.assertEqual(chains.dump_chains(node.body[0]),
                          ['foo -> ('
-                          'foo -> (comprehension -> (ListComp -> ())), '
-                          'foo -> (comprehension -> (SetComp -> ())), '
-                          'foo -> (comprehension -> (GeneratorExp -> ())), '
-                          'foo -> (comprehension -> (DictComp -> ())))'])
+                          'foo -> (<comprehension> -> (<listcomp> -> ())), '
+                          'foo -> (<comprehension> -> (<setcomp> -> ())), '
+                          'foo -> (<comprehension> -> (<generatorexp> -> ())), '
+                          'foo -> (<comprehension> -> (<dictcomp> -> ())))'])
     
     def test_class_scope_comprehension_invalid(self):
         code = '''
@@ -689,7 +689,7 @@ class Foo:
 if (x := 1):
     y = x + 1'''
         self.checkChains(
-            code, ['x -> (x -> (BinOp -> ()))', 'y -> ()']
+            code, ['x -> (x -> (<binop> -> ()))', 'y -> ()']
         )
 
     @skipIf(sys.version_info < (3, 8), 'Python 3.8 syntax')
@@ -698,7 +698,7 @@ if (x := 1):
 if (x := (y := 1) + 1):
     z = x + y'''
         self.checkChains(
-            code, ['y -> (y -> (BinOp -> ()))', 'x -> (x -> (BinOp -> ()))', 'z -> ()']
+            code, ['y -> (y -> (<binop> -> ()))', 'x -> (x -> (<binop> -> ()))', 'z -> ()']
         )
 
     @skipIf(sys.version_info < (3, 8), 'Python 3.8 syntax')
@@ -708,7 +708,7 @@ a = 1
 if (a := a + a):
     pass'''
         self.checkChains(
-            code, ['a -> (a -> (BinOp -> (NamedExpr -> ())), a -> (BinOp -> (NamedExpr -> ())))', 'a -> ()']
+            code, ['a -> (a -> (<binop> -> (<namedexpr> -> ())), a -> (<binop> -> (<namedexpr> -> ())))', 'a -> ()']
         )
     
     @skipIf(sys.version_info < (3, 8), 'Python 3.8 syntax')
@@ -718,7 +718,7 @@ if (a := a + a):
             'if any((witness := city).startswith("H") for city in cities):'
             'witness')
         self.checkChains(
-            code, ['cities -> (cities -> (comprehension -> (GeneratorExp -> (Call -> ()))))', 
+            code, ['cities -> (cities -> (<comprehension> -> (<generatorexp> -> (<call> -> ()))))', 
                    'witness -> (witness -> ())']
         )
         
@@ -807,7 +807,7 @@ class S:
     def test_import_dotted_name_binds_first_name(self):
         code = '''import collections.abc;collections;collections.abc'''
         self.checkChains(
-            code, ['collections -> (collections -> (), collections -> (Attribute -> ()))']
+            code, ['collections -> (collections -> (), collections -> (<attribute> -> ()))']
         )
 
     def test_multiple_wildcards_may_bind(self):
@@ -837,8 +837,8 @@ class System:
     def Attr(self) -> Union[Attr, Thing]:...
 '''
         self.checkChains(
-            code, ['Union -> (Union -> (Subscript -> ()))',
-                    'Attr -> (Attr -> (Tuple -> (Subscript -> ())))',
+            code, ['Union -> (Union -> (<subscript> -> ()))',
+                    'Attr -> (Attr -> (<tuple> -> (<subscript> -> ())))',
                     'Thing -> ()',
                     'System -> ()',]
         )
@@ -855,11 +855,11 @@ class System:
         
         mod, chains = self.checkChains(
             code, ['annotations -> ()',
-            'Type -> (Type -> (Subscript -> ()))', 'System -> ()']
+            'Type -> (Type -> (<subscript> -> ()))', 'System -> ()']
         )
         # locals of System
         self.assertEqual(chains.dump_chains(mod.body[-1]), [
-            'Thing -> (Thing -> (Subscript -> ()))', 
+            'Thing -> (Thing -> (<subscript> -> ()))', 
             'Attribute -> ()'
         ])
         
@@ -922,10 +922,10 @@ Thing:TypeAlias = 'Mapping'
                     'TypeAlias -> (TypeAlias -> (), TypeAlias -> (), TypeAlias -> ())',
                     'Mapping -> ()',
                     'Dict -> ()',
-                    'Type -> (Type -> (Subscript -> ()))',
-                    'C -> (C -> (Attribute -> ()), C -> (Attribute -> ()), C -> (Attribute -> '
-                    '(Attribute -> ())))',
-                    'Thing -> (Thing -> (), Thing -> (Subscript -> ()))'], 
+                    'Type -> (Type -> (<subscript> -> ()))',
+                    'C -> (C -> (<attribute> -> ()), C -> (<attribute> -> ()), C -> (<attribute> -> '
+                    '(<attribute> -> ())))',
+                    'Thing -> (Thing -> (), Thing -> (<subscript> -> ()))'], 
                 strict=False
             )
         produced_messages = out.getvalue().strip().split("\n")
@@ -998,13 +998,13 @@ primes: List[int] # should resolve to the star
 
         self.checkChains(
                 code, 
-                ['* -> (List -> (Subscript -> ()))', 'primes -> ()'],
+                ['* -> (List -> (<subscript> -> ()))', 'primes -> ()'],
                 strict=False
             )
         # same with 'from __future__ import annotations'
         self.checkChains(
                 'from __future__ import annotations\n' + code, 
-                ['annotations -> ()', '* -> (List -> (Subscript -> ()))', 'primes -> ()'],
+                ['annotations -> ()', '* -> (List -> (<subscript> -> ()))', 'primes -> ()'],
                 strict=False
             )
     
@@ -1024,7 +1024,7 @@ List = list
                 ['annotations -> ()',
                 '* -> ()',
                 'primes -> ()',
-                'List -> (List -> (Subscript -> ()))'],
+                'List -> (List -> (<subscript> -> ()))'],
                 strict=False
             )
     
@@ -1045,7 +1045,7 @@ X = generate()
         mod, chains = self.checkChains(
                 code, 
                 ['A -> ()', 
-                 'generate -> (generate -> (Call -> ()))', 
+                 'generate -> (generate -> (<call> -> ()))', 
                  'X -> ()'],
             )
         self.assertEqual(chains.dump_chains(mod.body[1]), 
@@ -1057,7 +1057,7 @@ X = generate()
                 'from __future__ import annotations\n' + code, 
                 ['annotations -> ()', 
                  'A -> (A -> (), A -> ())',
-                 'generate -> (generate -> (Call -> ()))', 
+                 'generate -> (generate -> (<call> -> ()))', 
                  'X -> ()'],
             )
         self.assertEqual(chains.dump_chains(mod.body[2]), 
@@ -1093,12 +1093,12 @@ fn = outer()
                 chains.dump_chains(mod), 
                 ['mytype -> ()', 
                  'mytype2 -> ()', 
-                 'outer -> (outer -> (Call -> ()))', 
+                 'outer -> (outer -> (<call> -> ()))', 
                  'fn -> ()'],
             )
         
         self.assertEqual(chains.dump_chains(mod.body[1]), 
-                         ['middle -> (middle -> (Call -> ()))', 
+                         ['middle -> (middle -> (<call> -> ()))', 
                           'mytype2 -> (mytype2 -> ())'])
         self.assertEqual(chains.dump_chains(mod.body[1].body[0]), 
                          ['inner -> (inner -> ())', 
@@ -1111,11 +1111,11 @@ fn = outer()
                 ['annotations -> ()', 
                  'mytype -> (mytype -> ())', 
                  'mytype2 -> (mytype2 -> ())', 
-                 'outer -> (outer -> (Call -> ()))', 
+                 'outer -> (outer -> (<call> -> ()))', 
                  'fn -> ()'],
             )
         self.assertEqual(chains.dump_chains(mod.body[2]), 
-                         ['middle -> (middle -> (Call -> ()))', 
+                         ['middle -> (middle -> (<call> -> ()))', 
                           'mytype2 -> ()'])
         self.assertEqual(chains.dump_chains(mod.body[2].body[0]), 
                          ['inner -> (inner -> ())', 
@@ -1203,33 +1203,33 @@ fn = outer()
                 ['annotations -> ()',
                 'mytype -> (mytype -> (), mytype -> (), mytype -> (), mytype -> ())',
                 'mytype2 -> (mytype2 -> (), mytype2 -> ())',
-                'outer -> (outer -> (Call -> ()))',
+                'outer -> (outer -> (<call> -> ()))',
                 'fn -> ()'],
             )
         self.assertEqual(chains.dump_chains(mod.body[2]), 
-                         ['middle -> (middle -> (Call -> ()))',
-                          'mytype2 -> (mytype2 -> (Call -> (Call -> ())), '
-                          'mytype2 -> (Call -> (Call -> ())))'])
+                         ['middle -> (middle -> (<call> -> ()))',
+                          'mytype2 -> (mytype2 -> (<call> -> (<call> -> ())), '
+                          'mytype2 -> (<call> -> (<call> -> ())))'])
         self.assertEqual(chains.dump_chains(mod.body[2].body[0]), 
-                         ['inner -> (inner -> (Call -> ()))',
-                          'mytype -> (mytype -> (Call -> (Call -> ())), mytype -> (Call -> ()))'])
+                         ['inner -> (inner -> (<call> -> ()))',
+                          'mytype -> (mytype -> (<call> -> (<call> -> ())), mytype -> (<call> -> ()))'])
 
         mod, chains = self.checkChains(
                 code.replace('mytype = mytype2 = object', 'pass'), 
                 ['annotations -> ()',
-                'outer -> (outer -> (Call -> ()))',
+                'outer -> (outer -> (<call> -> ()))',
                 'fn -> ()'],
             )
         self.assertEqual(chains.dump_chains(mod.body[2]), 
-                         ['middle -> (middle -> (Call -> ()))',
-                          'mytype2 -> (mytype2 -> (Call -> (Call -> ())), '
-                                       'mytype2 -> (Call -> (Call -> ())), '
+                         ['middle -> (middle -> (<call> -> ()))',
+                          'mytype2 -> (mytype2 -> (<call> -> (<call> -> ())), '
+                                       'mytype2 -> (<call> -> (<call> -> ())), '
                                        'mytype2 -> (), '
                                        'mytype2 -> ())'])
         self.assertEqual(chains.dump_chains(mod.body[2].body[0]), 
-                         ['inner -> (inner -> (Call -> ()))',
-                          'mytype -> (mytype -> (Call -> (Call -> ())), '
-                                     'mytype -> (Call -> ()), '
+                         ['inner -> (inner -> (<call> -> ()))',
+                          'mytype -> (mytype -> (<call> -> (<call> -> ())), '
+                                     'mytype -> (<call> -> ()), '
                                      'mytype -> (), '
                                      'mytype -> (), '
                                      'mytype -> (), '
@@ -1280,8 +1280,8 @@ match command.split():
     case _:
         raise ValueError("Sorry")
         '''
-        self.checkChains(code, ['command -> (command -> (Attribute -> (Call -> ())))',
-                                'direction -> (MatchSequence -> (), direction -> (Call -> ()))'])
+        self.checkChains(code, ['command -> (command -> (<attribute> -> (<call> -> ())))',
+                                'direction -> (<matchsequence> -> (), direction -> (<call> -> ()))'])
 
     @skipIf(sys.version_info < (3,10), "Python 3.10 syntax")
     def test_match_list_star(self):
@@ -1292,9 +1292,9 @@ match command.split():
     case ["drop", *objects]:
         print(objects)
         '''
-        self.checkChains(code, ['command -> (command -> (Attribute -> (Call -> ())))',
-                                'direction -> (MatchSequence -> ())',
-                                'objects -> (MatchSequence -> (), objects -> (Call -> ()))'])
+        self.checkChains(code, ['command -> (command -> (<attribute> -> (<call> -> ())))',
+                                'direction -> (<matchsequence> -> ())',
+                                'objects -> (<matchsequence> -> (), objects -> (<call> -> ()))'])
 
     @skipIf(sys.version_info < (3,10), "Python 3.10 syntax")
     def test_match_dict(self):
@@ -1314,13 +1314,13 @@ match action:
         raise ValueError("Unsupported audio format")
 print(c)
         '''
-        self.checkChains(code, ['ui -> (ui -> (Attribute -> (Call -> ())), ui -> (Attribute -> (Call -> ())), ui -> (Attribute -> (Call -> ())), ui -> (Attribute -> (Call -> ())))',
+        self.checkChains(code, ['ui -> (ui -> (<attribute> -> (<call> -> ())), ui -> (<attribute> -> (<call> -> ())), ui -> (<attribute> -> (<call> -> ())), ui -> (<attribute> -> (<call> -> ())))',
                                 'action -> (action -> ())',
-                                'message -> (MatchClass -> (rest -> (rest -> (Call -> ()))), message -> (Call -> ()))',
-                                'c -> (MatchClass -> (rest -> (rest -> (Call -> ()))), c -> (Call -> ()), c -> (Call -> ()))',
-                                'rest -> (rest -> (Call -> ()))',
-                                'duration -> (MatchClass -> (MatchMapping -> ()), duration -> (Call -> ()))',
-                                'url -> (MatchClass -> (MatchMapping -> ()), url -> (Call -> ()))'])
+                                'message -> (<matchclass> -> (rest -> (rest -> (<call> -> ()))), message -> (<call> -> ()))',
+                                'c -> (<matchclass> -> (rest -> (rest -> (<call> -> ()))), c -> (<call> -> ()), c -> (<call> -> ()))',
+                                'rest -> (rest -> (<call> -> ()))',
+                                'duration -> (<matchclass> -> (<matchmapping> -> ()), duration -> (<call> -> ()))',
+                                'url -> (<matchclass> -> (<matchmapping> -> ()), url -> (<call> -> ()))'])
 
     @skipIf(sys.version_info < (3,10), "Python 3.10 syntax")
     def test_match_class_rebinds_attrs(self):
@@ -1348,13 +1348,13 @@ match point:
 print(x, y)
         '''
         self.checkChains(
-                code, ['dataclass -> (dataclass -> (Point -> (Point -> (Call -> ()), Point -> (MatchClass -> ()), Point -> (MatchClass -> ()), Point -> (MatchClass -> ()), Point -> (MatchClass -> ()))))',
-                       'Point -> (Point -> (Call -> ()), Point -> (MatchClass -> ()), Point -> (MatchClass -> ()), Point -> (MatchClass -> ()), Point -> (MatchClass -> ()))',
+                code, ['dataclass -> (dataclass -> (Point -> (Point -> (<call> -> ()), Point -> (<matchclass> -> ()), Point -> (<matchclass> -> ()), Point -> (<matchclass> -> ()), Point -> (<matchclass> -> ()))))',
+                       'Point -> (Point -> (<call> -> ()), Point -> (<matchclass> -> ()), Point -> (<matchclass> -> ()), Point -> (<matchclass> -> ()), Point -> (<matchclass> -> ()))',
                        'point -> (point -> ())',
-                       'y -> (MatchClass -> (), y -> (FormattedValue -> (JoinedStr -> (Call -> ()))), y -> (Call -> ()))',
-                       'x -> (MatchClass -> (), x -> (FormattedValue -> (JoinedStr -> (Call -> ()))), x -> (Call -> ()))',
-                       'x -> (MatchClass -> (), x -> (Call -> ()))',
-                       'y -> (MatchClass -> (), y -> (Call -> ()))'])
+                       'y -> (<matchclass> -> (), y -> (<formattedvalue> -> (<joinedstr> -> (<call> -> ()))), y -> (<call> -> ()))',
+                       'x -> (<matchclass> -> (), x -> (<formattedvalue> -> (<joinedstr> -> (<call> -> ()))), x -> (<call> -> ()))',
+                       'x -> (<matchclass> -> (), x -> (<call> -> ()))',
+                       'y -> (<matchclass> -> (), y -> (<call> -> ()))'])
 
 class TestUseDefChains(TestCase):
     def checkChains(self, code, ref):
@@ -1379,4 +1379,4 @@ class TestUseDefChains(TestCase):
 
     def test_call(self):
         code = "from foo import bar; bar(1, 2)"
-        self.checkChains(code, "Call <- {Constant, Constant, bar}, bar <- {bar}")
+        self.checkChains(code, "<call> <- {<constant>, <constant>, bar}, bar <- {bar}")

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -345,8 +345,8 @@ while done:
                                     'y -> ()',
                                     'z -> (z -> (<tuple> -> (<lambda> -> ())))']) 
         self.assertEqual(c.dump_chains(node.body[1].value), [
-            'y -> (y -> (Tuple -> (<lambda> -> ())))',
-            'x -> (x -> (Tuple -> (<lambda> -> ())))',
+            'y -> (y -> (<tuple> -> (<lambda> -> ())))',
+            'x -> (x -> (<tuple> -> (<lambda> -> ())))',
         ])
 
     def test_lambda_varargs(self):


### PR DESCRIPTION
Now use `f'<{type(self.node).__name__}>'`.

Fixes #98 