### PR TITLE
[maintenance] Fix erroneous base class for the standard library use-def tests

### DIFF
--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -1562,7 +1562,7 @@ class TestUseDefChains(TestCase):
         cc = beniget.UseDefChains(c)
         actual = str(cc)
 
-        # work arround Constant simplicifation from Python 3.8
+        # work around Constant simplification from Python 3.8
         if sys.version_info.minor in {6, 7}:
             # 3.6 or 3.7
             actual = replace_deprecated_names(actual)

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -1557,21 +1557,13 @@ class TestUseDefChains(TestCase):
     def checkChains(self, code, ref):
         node = self.ast.parse(code)
 
-        class StrictDefUseChains(beniget.DefUseChains):
-            def unbound_identifier(self, name, node):
-                raise RuntimeError(
-                    "W: unbound identifier '{}' at {}:{}".format(
-                        name, node.lineno, node.col_offset
-                    )
-                )
-
         c = StrictDefUseChains()
         c.visit(node)
         cc = beniget.UseDefChains(c)
         actual = str(cc)
 
-        # work arround little change from python 3.8
-        if sys.version_info <= (3, 7):
+        # work arround Constant simplicifation from Python 3.8
+        if sys.version_info.minor in {6, 7}:
             # 3.6 or 3.7
             actual = replace_deprecated_names(actual)
 

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -1414,6 +1414,6 @@ class TestUseDefChains(TestCase):
         code = "from foo import bar; bar(1, 2)"
         self.checkChains(code, "<Call> <- {<Constant>, <Constant>, bar}, bar <- {bar}")
 
-class TestUseDefChainsStdlib(TestDefUseChains):
+class TestUseDefChainsStdlib(TestUseDefChains):
     ast = _ast
 

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -14,13 +14,13 @@ unittest.util._MAX_LENGTH=2000
 
 def replace_deprecated_names(out):
     return out.replace(
-        'Num', 'Constant'
+        '<Num>', '<Constant>'
     ).replace(
-        'Ellipsis', 'Constant'
+        '<Ellipsis>', '<Constant>'
     ).replace(
-        'Str', 'Constant'
+        '<Str>', '<Constant>'
     ).replace(
-        'Bytes', 'Constant'
+        '<Bytes>', '<Constant>'
     )
 
 @contextmanager
@@ -1570,9 +1570,9 @@ class TestUseDefChains(TestCase):
         cc = beniget.UseDefChains(c)
         actual = str(cc)
 
-        # work arround little change from python 3.6
-        if sys.version_info.minor == 6:
-            # 3.6
+        # work arround little change from python 3.8
+        if sys.version_info <= (3, 7):
+            # 3.6 or 3.7
             actual = replace_deprecated_names(actual)
 
         self.assertEqual(actual, ref)


### PR DESCRIPTION
This is my fault, sorry, but hey, all tests passes.