### PR TITLE
[maintenance] Update Python version under test to include 3.14-dev

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-          python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13.0-rc.2"]
+          python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14-dev"]
           include:
             - python-version: "3.6"
               os: ubuntu-20.04


### PR DESCRIPTION
And use the stable branch of Python 3.13 as a drive-by change. 