### PR TITLE
[maintenance] PyPI release inside the GitHub actions

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -55,3 +55,30 @@ jobs:
             python -m pip install .
             pytest --doctest-modules beniget/ tests/
           "
+  release:
+      needs: [ build ]
+      name: PyPI
+      runs-on: ubuntu-latest
+      environment: pypi
+      permissions:
+        id-token: write
+      steps:
+        - uses: actions/checkout@v4
+
+        - name: Set up Python 3.12
+          uses: actions/setup-python@v5
+          with:
+            python-version: 3.12
+        
+        - name: Install build dependencies
+          run: |
+            python -m pip install -U setuptools wheel
+
+        - name: Build
+          run: |
+            python setup.py --quiet build check sdist bdist_wheel
+            ls -alh ./dist/
+
+        - name: Publish to PyPI - on tag
+          if: startsWith(github.ref, 'refs/tags/')
+          uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Hello Serge, 

This PR fixes #107. It uses the PyPI trusted publisher method. In order for PyPI to trust this pipeline, you need to configure it on the beniget package on PyPI at https://pypi.org/manage/project/beniget/settings/publishing/ like 
<img width="401" alt="Capture d’écran, le 2025-06-14 à 13 30 47" src="https://github.com/user-attachments/assets/6dc24c62-6481-4265-91be-47b57ac6378f" />

Then the release process should be simple as:
- Edit version.py to update the version number and create a PR with this change.
- Once that PR is merged, the owner pushes a new tag with the same name as the version. This will trigger the PyPi release process. 
- Monitor the process in the GitHub action UI...