### PR TITLE
[language feature] Support PEP695 and PEP696 - Type parameters

### DIFF
--- a/beniget/__init__.py
+++ b/beniget/__init__.py
@@ -15,6 +15,7 @@ from beniget.version import __version__
 from beniget.beniget import (Ancestors, 
                              DefUseChains, 
                              UseDefChains,
-                             Def, )
+                             Def, 
+                             TypeParamScope, )
 
-__all__ = ['Ancestors', 'DefUseChains', 'UseDefChains', 'Def', '__version__']
+__all__ = ['Ancestors', 'DefUseChains', 'UseDefChains', 'Def', 'TypeParamScope', '__version__']

--- a/beniget/beniget.py
+++ b/beniget/beniget.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 import builtins
 import sys
 
@@ -163,6 +163,8 @@ class Def(object):
             return self.node.name
         elif self.node.__class__.__name__ == 'MatchMapping' and self.node.rest:
             return self.node.rest
+        elif self.node.__class__.__name__ in ('TypeVar', 'TypeVarTuple', 'ParamSpec'):
+            return self.node.name
         elif isinstance(self.node, ast.Attribute):
             return "." + self.node.attr
         elif isinstance(self.node, tuple):
@@ -322,15 +324,66 @@ class CollectLocals(gast.NodeVisitor):
         for alias in node.names:
             self.Locals.add(alias.asname or alias.name)
 
+class CollectLocalsTypeParamScope(CollectLocals):
+    visit_TypeVar = visit_ParamSpec = visit_TypeVarTuple = CollectLocals.visit_FunctionDef
+
 def collect_locals(node):
     '''
     Compute the set of identifiers local to a given node.
 
     This is meant to emulate a call to locals()
     '''
-    visitor = CollectLocals()
+    if isinstance(node, TypeParamScope):
+        # special-case the new annotation scope created by type parameters
+        visitor = CollectLocalsTypeParamScope()
+    else:
+        visitor = CollectLocals()
     visitor.generic_visit(node)
     return visitor.Locals
+
+class TypeParamScope(gast.stmt):
+    r"""
+    Special AST node to represent the PEP-695 lexical scopes (A.k.a annotation scopes).
+
+    Only used in the context of type parameters of generic classes/functions or type aliases. 
+    (We have another mecanism to handle annotations)
+
+    Example usage:
+
+    >>> import ast, unittest, sys
+    >>> from beniget import DefUseChains, TypeParamScope
+    >>> module = ast.parse('class ClassA[T]:\n def func(self, x: T) -> T: ...') # doctest: +SKIP
+    >>> (duc := DefUseChains()).visit(module) # doctest: +SKIP
+    >>> # Prints the locals of the type parameter scope of the class:
+    >>> print(duc.dump_chains(TypeParamScope(module.body[0]))) # doctest: +SKIP
+    ['T -> (T -> (), T -> ())']
+
+    """
+    _fields = ('body', 'd')
+    
+    def __init__(self, d):
+        """
+        :param d: The wrapped definition node. 
+        :type d: ast.FunctionDef | ast.ClassDef | ast.TypeAlias
+        """
+        self.d = d
+    
+    @property
+    def body(self):
+        """
+        :returns: The type parameters declared in the annotation scope.
+        :rtype: list[ast.TypeVar | ast.TypeVarTuple | ast.ParamSpec]
+        """
+        return getattr(self.d, 'type_params', [])
+    
+    def __hash__(self):
+        return hash(id(self.d)+1)
+    
+    def __eq__(self, value):
+        if not isinstance(value, TypeParamScope):
+            return NotImplemented
+        return self.d == value.d
+        
 
 class DefUseChains(gast.NodeVisitor):
     """
@@ -400,7 +453,7 @@ class DefUseChains(gast.NodeVisitor):
         # be defined in another path of the control flow (esp. in loop)
         self._undefs = []
 
-        # stack of nodes starting a scope: class, module, function, generator expression, comprehension...
+        # stack of nodes starting a scope: class, module, function, generator expression, comprehension, TypeParamScope...
         self._scopes = []
 
         self._breaks = []
@@ -422,6 +475,10 @@ class DefUseChains(gast.NodeVisitor):
         """
 
         self.future_annotations = False
+        """
+        Flag indicates the use of ``from __future__ import annotations``. 
+        It should also be manually turned on to support Python3.14+'s annotation scopes. 
+        """
 
     #
     ## test helpers
@@ -534,6 +591,7 @@ class DefUseChains(gast.NodeVisitor):
         lvl = depth = next(depths_iter)
         precomputed_locals = next(precomputed_locals_iter)
         base_scope = next(scopes_iter)
+        base_scope_is_TypeParamScope = isinstance(base_scope, TypeParamScope)
         defs = self._definitions[depth:]
         if not self.invalid_name_lookup(name, base_scope, precomputed_locals, defs):
 
@@ -551,11 +609,12 @@ class DefUseChains(gast.NodeVisitor):
             add_defs(looked_up_definitions, defs)
 
             ast = pkg(node)
-            # Iterate over scopes, filtering out class scopes.
+            # Iterate over scopes, filtering out class scopes, except if the enclosing
+            # scope is a TypeParamScope.
             for scope, depth, precomputed_locals in zip(scopes_iter,
                                                         depths_iter,
                                                         precomputed_locals_iter):
-                if not isinstance(scope, ast.ClassDef):
+                if not isinstance(scope, ast.ClassDef) or base_scope_is_TypeParamScope:
                     defs = self._definitions[lvl + depth: lvl]
                     if self.invalid_name_lookup(name, base_scope, precomputed_locals, defs):
                         looked_up_definitions.append(StopIteration)
@@ -852,16 +911,34 @@ class DefUseChains(gast.NodeVisitor):
             self.locals[self.module].add(dnode)
         DefUseChains.add_to_definition(self._definitions[0], name, dnode)
 
-    def visit_annotation(self, node):
-        annotation = getattr(node, 'annotation', None)
+    def visit_annotation(self, node, *, defer:bool, field='annotation'):
+        annotation = getattr(node, field, None)
         if annotation:
-            self.visit(annotation)
+            if defer:
+                # only validate annotation if they are meant to be deferred.
+                # Stock semantics don't care about named expressions in annotations.
+                try:
+                    _validate_annotation_body(annotation)
+                except SyntaxError as e:
+                    self.warn(str(e), annotation)
+                    return
+                self._defered_annotations[-1].append(
+                    (annotation, list(self._scopes), None))
+            else:
+                self.visit(annotation)
 
     def visit_skip_annotation(self, node):
         if isinstance(node, pkg(node).Name):
             self.visit_Name(node, skip_annotation=True)
         else:
             self.visit(node)
+
+    def get_annotation_context(self, node):
+        if getattr(node, 'type_params', None):
+            annotation_context = self.ScopeContext(TypeParamScope(node))
+        else:
+            annotation_context = suppress()
+        return annotation_context
 
     def visit_FunctionDef(self, node, step=DeclarationStep):
         if step is DeclarationStep:
@@ -874,32 +951,22 @@ class DefUseChains(gast.NodeVisitor):
                 self.visit(kw_default).add_user(dnode)
             for decorator in node.decorator_list:
                 self.visit(decorator)
+            
+            with self.get_annotation_context(node):
+                self.visit_type_params(node)
 
-            if not self.future_annotations:
                 for arg in _iter_arguments(node.args):
-                    self.visit_annotation(arg)
+                    self.visit_annotation(arg, defer=self.future_annotations)
+                self.visit_annotation(node, defer=self.future_annotations, field='returns')
 
-            else:
-                # annotations are to be analyzed later as well
-                currentscopes = list(self._scopes)
-                if node.returns:
-                    self._defered_annotations[-1].append(
-                        (node.returns, currentscopes, None))
-                for arg in _iter_arguments(node.args):
-                    if arg.annotation:
-                        self._defered_annotations[-1].append(
-                            (arg.annotation, currentscopes, None))
-
-            if not self.future_annotations and node.returns:
-                self.visit(node.returns)
-
+                self._defered.append((node,
+                                    list(self._definitions),
+                                    list(self._scopes),
+                                    list(self._scope_depths),
+                                    list(self._precomputed_locals)))
+            
             self.set_definition(node.name, dnode)
 
-            self._defered.append((node,
-                                  list(self._definitions),
-                                  list(self._scopes),
-                                  list(self._scope_depths),
-                                  list(self._precomputed_locals)))
         elif step is DefinitionStep:
             with self.ScopeContext(node):
                 for arg in _iter_arguments(node.args):
@@ -916,14 +983,18 @@ class DefUseChains(gast.NodeVisitor):
 
         for decorator in node.decorator_list:
             self.visit(decorator).add_user(dnode)
-        for base in node.bases:
-            self.visit(base).add_user(dnode)
-        for keyword in node.keywords:
-            self.visit(keyword.value).add_user(dnode)
 
-        with self.ScopeContext(node):
-            self.set_definition("__class__", Def("__class__"))
-            self.process_body(node.body)
+        with self.get_annotation_context(node):
+            self.visit_type_params(node)
+        
+            for base in node.bases:
+                self.visit(base).add_user(dnode)
+            for keyword in node.keywords:
+                self.visit(keyword.value).add_user(dnode)
+
+            with self.ScopeContext(node):
+                self.set_definition("__class__", Def("__class__"))
+                self.process_body(node.body)
 
         self.set_definition(node.name, dnode)
 
@@ -955,11 +1026,7 @@ class DefUseChains(gast.NodeVisitor):
     def visit_AnnAssign(self, node):
         if node.value:
             self.visit(node.value)
-        if not self.future_annotations:
-            self.visit(node.annotation)
-        else:
-            self._defered_annotations[-1].append(
-                (node.annotation, list(self._scopes), None))
+        self.visit_annotation(node, defer=self.future_annotations)
         self.visit(node.target)
 
     def visit_AugAssign(self, node):
@@ -981,6 +1048,21 @@ class DefUseChains(gast.NodeVisitor):
                     self.add_to_locals(node.target.id, dtarget)
         else:
             self.visit(node.target).add_user(dvalue)
+    
+    def visit_TypeAlias(self, node):
+        ast = pkg(node)
+
+        if not isinstance(node.name, ast.Name):
+            raise NotImplementedError()
+        
+        dname = self.chains.setdefault(node.name, Def(node.name))
+        self.add_to_locals(node.name.id, dname)
+
+        with self.get_annotation_context(node):
+            self.visit_type_params(node)
+            self.visit_annotation(node, defer=True, field='value')
+
+        self.set_definition(node.name.id, dname)           
 
     def visit_For(self, node):
         self.visit(node.iter)
@@ -1180,10 +1262,17 @@ class DefUseChains(gast.NodeVisitor):
             self._nonlocals[-1].add(name)
             # Exclude global scope
             global_scope_depth = -self._scope_depths[0]
-            for d in reversed(self._definitions[global_scope_depth: -1]):
+            for i,d in enumerate(reversed(self._definitions[global_scope_depth:])):
+                if i == 0:
+                    continue
                 if name not in d:
                     continue
                 else:
+                    if isinstance(self._scopes[-i-1], TypeParamScope):
+                        # Special lint for names in annotation scopes, see 
+                        # https://docs.python.org/3.12/reference/executionmodel.html#annotation-scopes
+                        self.warn("names defined in annotation scopes cannot be rebound with nonlocal statements", node)
+                        break
                     # this rightfully creates aliasing
                     self.set_definition(name, d[name])
                     break
@@ -1472,6 +1561,27 @@ class DefUseChains(gast.NodeVisitor):
         if node.step:
             self.visit(node.step).add_user(dnode)
         return dnode
+    
+    # type parameters, these nodes can only be visited under a TypeParamScope scope
+
+    def visit_type_params(self, node):
+        # visit the type params
+        for p in getattr(node, 'type_params', []):
+            self.visit(p)
+
+    def visit_TypeVarTuple(self, node):
+        dnode = self.chains.setdefault(node, Def(node))
+        self.set_definition(node.name, dnode)
+        self.add_to_locals(node.name, dnode)
+        self.visit_annotation(node, defer=True, field='default_value')
+        return dnode
+
+    visit_ParamSpec = visit_TypeVarTuple
+
+    def visit_TypeVar(self, node):
+        dnode = self.visit_TypeVarTuple(node)
+        self.visit_annotation(node, defer=True, field='bound')
+        return dnode
 
     # misc
 
@@ -1622,6 +1732,25 @@ if not sys.version_info >= (3, 8):
     # since it only needs to be validated if the warlus operator is supported.
     def _validate_comprehension(node): return
 
+_node_type_to_human_name = {
+    'NamedExpr': 'assignment expression',
+    'Yield': 'yield keyword',
+    'YieldFrom': 'yield keyword',
+    'Await': 'await keyword',
+}
+
+def _validate_annotation_body(node):
+    """
+    Raises SyntaxError if:
+    - the warlus operator is used
+    - the yield/ yield from statement is used
+    - the await keyword is used
+    """
+    for illegal in (n for n in gast.walk(node) if type(n).__name__ in  
+                    ('NamedExpr', 'Yield', 'YieldFrom', 'Await')):
+        name = _node_type_to_human_name.get(type(illegal).__name__, 'current syntax')
+        raise SyntaxError(f'{name} cannot be used in annotation-like scopes')
+
 def lookup_annotation_name_defs(name, heads, locals_map):
     r"""
     Simple identifier -> defs resolving.
@@ -1665,11 +1794,12 @@ def lookup_annotation_name_defs(name, heads, locals_map):
     """
     scopes = _get_lookup_scopes(heads)
     scopes_len = len(scopes)
-    if scopes_len>1:
+    if scopes_len > 1 and not isinstance(scopes[-1], TypeParamScope):
         # start by looking at module scope first,
         # then try the theoretical runtime scopes.
         # putting the global scope last in the list so annotation are
         # resolve using he global namespace first. this is the way pyright does.
+        # EXCEPT is we're direcly inside a pep695 scope, in this case follow usual rules.
         scopes.append(scopes.pop(0))
     try:
         return _lookup(name, scopes, locals_map)
@@ -1684,23 +1814,27 @@ def _get_lookup_scopes(heads):
 
     heads = list(heads) # avoid modifying the list (important)
     try:
-        direct_scope = heads.pop(-1) # this scope is the only one that can be a class
+        direct_scopes = [heads.pop(-1)] # this scope is the only one that can be a class, expect in case of the presence of TypeParamScope
     except IndexError:
         raise ValueError('invalid heads: must include at least one element')
     try:
         global_scope = heads.pop(0)
     except IndexError:
         # we got only a global scope
-        return [direct_scope]
+        return direct_scopes
+    
+    ast = pkg(global_scope)
+    if heads and isinstance(direct_scopes[-1], TypeParamScope) and isinstance(heads[-1], ast.ClassDef):
+        # include the enclosing class scope in case we're in a TypeParamScope scope
+        direct_scopes.insert(0, heads.pop(-1))
 
-    ast = pkg(direct_scope)
     # more of less modeling what's described here.
     # https://github.com/gvanrossum/gvanrossum.github.io/blob/main/formal/scopesblog.md
     other_scopes = [s for s in heads if isinstance(s, (
                   ast.FunctionDef, ast.AsyncFunctionDef,
                   ast.Lambda, ast.DictComp, ast.ListComp,
-                  ast.SetComp, ast.GeneratorExp))]
-    return [global_scope] + other_scopes + [direct_scope]
+                  ast.SetComp, ast.GeneratorExp, TypeParamScope))]
+    return [global_scope] + other_scopes + direct_scopes
 
 def _lookup(name, scopes, locals_map):
     # For annotation resolution only!

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from textwrap import dedent
 from unittest import TestCase, skipIf
 import unittest
 import beniget
@@ -7,7 +8,7 @@ import sys
 import ast as _ast
 import gast as _gast
 
-from beniget.beniget import _get_lookup_scopes
+from beniget.beniget import _get_lookup_scopes, TypeParamScope, collect_locals
 
 # Show full diff in unittest
 unittest.util._MAX_LENGTH=2000
@@ -33,7 +34,7 @@ class TestDefUseChains(TestCase):
     ast = _gast
 
     def checkChains(self, code, ref, strict=True):
-        node = self.ast.parse(code)
+        node = self.ast.parse(dedent(code))
         if strict:
             c = StrictDefUseChains()
         else:
@@ -43,7 +44,7 @@ class TestDefUseChains(TestCase):
         out = list(map(normalize_chain, c.dump_chains(node)))
         self.assertEqual(ref, out)
         return node, c
-
+    
     def test_simple_expression(self):
         code = "a = 1; a + 2"
         self.checkChains(code, ["a -> (a -> (<BinOp> -> ()))"])
@@ -508,7 +509,7 @@ def outer():
         self.assertEqual(c.dump_chains(node.body[0].body[0]), ['mytype -> (mytype -> (<Call> -> ()))'])
 
     def check_message(self, code, expected_messages, filename=None):
-        node = self.ast.parse(code)
+        node = self.ast.parse(dedent(code))
         c = beniget.DefUseChains(filename)
         with captured_output() as (out, err):
             c.visit(node)
@@ -1138,7 +1139,7 @@ Thing:TypeAlias = 'Mapping'
                     'Type -> (Type -> (<Subscript> -> ()))',
                     'C -> (C -> (.field -> ()), C -> (.D -> ()), C -> (.D -> '
                     '(.field2 -> ())))',
-                    'Thing -> (Thing -> (), Thing -> (<Subscript> -> ()))'],
+                    'Thing -> (Thing -> (<Subscript> -> ()), Thing -> ())'],
                 strict=False
             )
         produced_messages = out.getvalue().strip().split("\n")
@@ -1347,8 +1348,9 @@ fn = outer()
             yield self.ast.parse('lambda: True').body[0].value      # Lambda
             yield self.ast.parse('(x for x in list())').body[0].value  # GeneratorExp
             yield self.ast.parse('{k:v for k, v in dict().items()}').body[0].value  # DictComp
+            yield TypeParamScope(None)
 
-        mod, fn, cls, lambd, gen, comp = get_scopes()
+        mod, fn, cls, lambd, gen, comp, typeparams = get_scopes()
         assert isinstance(mod, self.ast.Module)
         assert isinstance(fn, self.ast.FunctionDef)
         assert isinstance(cls, self.ast.ClassDef)
@@ -1365,6 +1367,11 @@ fn = outer()
         assert _get_lookup_scopes((mod, fn)) == [mod, fn]
         assert _get_lookup_scopes((mod, cls)) == [mod, cls]
         assert _get_lookup_scopes((mod,)) == [mod]
+        assert _get_lookup_scopes((mod, typeparams)) == [mod, typeparams]
+        assert _get_lookup_scopes((mod, typeparams, typeparams)) == [mod, typeparams, typeparams]
+        assert _get_lookup_scopes((mod, cls, typeparams)) == [mod, cls, typeparams]
+        assert _get_lookup_scopes((mod, cls, cls, typeparams)) == [mod, cls, typeparams]
+        assert _get_lookup_scopes((mod, cls, cls, typeparams, fn)) == [mod, typeparams, fn]
 
         with self.assertRaises(ValueError, msg='invalid heads: must include at least one element'):
             _get_lookup_scopes(())
@@ -1485,6 +1492,571 @@ A = bytes
         code = 'from typing import Optional; var:Optional'
         self.checkChains(code, ['Optional -> (Optional -> ())',
                                 'var -> ()'])
+    
+    def test_pep563_disallowed_expressions(self):
+        cases = [
+            "def func(a: (yield)) -> ...: ...",
+            "def func(a: ...) -> (yield from []): ...",
+            "def func(*a: (y := 3)) -> ...: ...",
+            "def func(**a: (await 42)) -> ...: ...",
+
+            "x: (yield) = True",
+            "x: (yield from []) = True",
+            "x: (y := 3) = True",
+            "x: (await 42) = True",]
+
+        for code in cases:
+            if ':=' in code and sys.version_info < (3,8):
+                continue
+            if 'await' in code and sys.version_info < (3,7):
+                continue
+            code = f'from __future__ import annotations\n' + code
+            with self.subTest(code):
+                self.check_message(code, ['cannot be used in annotation-like scopes'])
+        
+        for code in cases:
+            if ':=' in code and sys.version_info < (3,8):
+                continue
+            if 'await' in code and sys.version_info < (3,7):
+                continue
+            with self.subTest(code):
+                # TODO: From python 3.14, this should generate the same error.
+                self.check_message(code, [])
+    
+    # PEP-695 test cases taken from https://github.com/python/cpython/pull/103764/files
+    # but also https://github.com/python/cpython/pull/109297/files and
+    # https://github.com/python/cpython/pull/109123/files
+
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_typeparams_name_collision_01(self):
+        # The following code triggers syntax error at runtime.
+        # But detecting this would required beniget to keep track of the 
+        # names of type parameters and validate them like we validate comprehensions or annotations. 
+        # We don't do it for functions currently, so it doesn't make sens to do it for 
+        # type parameters at this time.
+        code = """def func[**A, A](): ..."""
+        node, du = self.checkChains(code, ['func -> ()'])
+        assert du.dump_chains(TypeParamScope(node.body[0])) == ['A -> ()', 'A -> ()']
+    
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_typeparams_name_non_collision_02(self):
+        code = """def func[A](A): return A"""
+        node, du = self.checkChains(code, ['func -> ()'])
+        assert du.dump_chains(TypeParamScope(node.body[0])) == ['A -> ()']
+
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_typeparams_name_non_collision_03(self):
+        code = """def func[A](*A): return A"""
+        node, du = self.checkChains(code, ['func -> ()'])
+        func = node.body[0]
+        assert du.dump_chains(func) == ['A -> (A -> ())']
+        assert du.dump_chains(TypeParamScope(func)) == ['A -> ()']
+
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_typeparams_name_non_collision_04(self):
+        # Mangled names should not cause a conflict.
+        code = """class ClassA:\n def func[__A](self, __A): return __A"""
+        node, du = self.checkChains(code, ['ClassA -> ()'])
+        cls = node.body[0]
+        method = cls.body[0]
+        assert du.dump_chains(method) == ['self -> ()', '__A -> (__A -> ())']
+        assert du.dump_chains(TypeParamScope(method)) == ['__A -> ()']
+
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_typeparams_name_non_collision_05(self):
+        code = """class ClassA:\n def func[_ClassA__A](self, __A): return __A"""
+        node, du = self.checkChains(code, ['ClassA -> ()'])
+        cls = node.body[0]
+        method = cls.body[0]
+        assert du.dump_chains(method) == ['self -> ()', '__A -> (__A -> ())']
+        assert du.dump_chains(TypeParamScope(method)) == ['_ClassA__A -> ()']
+
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_typeparams_name_non_collision_06(self):
+        code = """class ClassA[X]:\n def func(self, X): return X"""
+        node, du = self.checkChains(code, ['ClassA -> ()'])
+        cls = node.body[0]
+        assert du.dump_chains(cls) == ['func -> ()']
+        assert du.dump_chains(TypeParamScope(cls)) == ['X -> ()']
+
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_typeparams_name_non_collision_07(self):
+        code = """class ClassA[X]:\n def func(self):\n  X = 1;return X"""
+        node, du = self.checkChains(code, ['ClassA -> ()'])
+        cls = node.body[0]
+        assert du.dump_chains(cls) == ['func -> ()']
+        assert du.dump_chains(TypeParamScope(cls)) == ['X -> ()']
+        
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_typeparams_name_non_collision_08(self):
+        code = """class ClassA[X]:\n def func(self): return [X for X in [1, 2]]"""
+        node, du = self.checkChains(code, ['ClassA -> ()'])
+        cls = node.body[0]
+        assert du.dump_chains(cls) == ['func -> ()']
+        assert du.dump_chains(TypeParamScope(cls)) == ['X -> ()']
+
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_typeparams_name_non_collision_09(self):
+        code = """class ClassA[X]:\n def func[X](self):..."""
+        node, du = self.checkChains(code, ['ClassA -> ()'])
+        cls = node.body[0]
+        method = cls.body[0]
+        assert du.dump_chains(cls) == ['func -> ()']
+        assert du.dump_chains(TypeParamScope(cls)) == ['X -> ()']
+        assert du.dump_chains(method) == ['self -> ()']
+        assert du.dump_chains(TypeParamScope(method)) == ['X -> ()']
+
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_typeparams_name_non_collision_10(self):
+        code = """class ClassA[X,Y]:\n Y: bytes\n X: int"""
+        node, du = self.checkChains(code, ['ClassA -> ()'])
+        cls = node.body[0]
+        assert du.dump_chains(cls) == ['Y -> ()', 'X -> ()']
+        assert du.dump_chains(TypeParamScope(cls)) == ['X -> ()', 'Y -> ()']
+
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_typeparams_name_non_collision_13(self):
+        code = """X = 1\ndef outer():\n def inner[X]():\n  global X;X=2\n return inner"""
+        node, chains = self.checkChains(code, ['X -> ()', 'outer -> ()'])
+        self.assertEqual(chains.dump_chains(node.body[-1]), ['inner -> (inner -> ())'])
+
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_typeparams_disallowed_expressions(self):
+        cases = ["type X = (yield)",
+        "type X = (yield from x)",
+        "type X = (await 42)",
+        "async def f(): type X = (yield)",
+        "type X = (y := 3)",
+        "class X[T: (yield)]: pass",
+        "class X[T: (yield from [])]: pass",
+        "class X[T: (await 42)]: pass",
+        "class X[T: (y := 3)]: pass",
+        ]
+
+        for code in cases:
+            with self.subTest(code):
+                self.check_message(code, ['cannot be used in annotation-like scopes'])
+        
+        for code in cases:
+            code = f'from __future__ import annotations\n' + code
+            with self.subTest(code):
+                self.check_message(code, ['cannot be used in annotation-like scopes'])
+    
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_type_alias_name_collision_01(self):
+        # syntax error at runtime "duplicate type parameter 'A'"
+        code = """type TA1[A, **A] = None"""
+        self.checkChains(code, ['TA1 -> ()'])
+    
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_type_alias_name_non_collision_02(self):
+        code = """type TA1[A] = lambda A: A"""
+        self.checkChains(code, ['TA1 -> ()'])
+
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_type_alias_name_non_collision_03(self):
+        code = """class Outer[A]:\n type TA1[A] = None"""
+        self.checkChains(code, ['Outer -> ()'])
+    
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_type_alias_access_01(self):
+        code = "type TA1[A, B] = dict[A, B]"
+        self.checkChains(code, ['TA1 -> ()'])
+
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_type_alias_access_02(self):
+        code = """type TA1[A, B] = TA1[A, B] | int"""
+        self.checkChains(code, ['TA1 -> (TA1 -> (<Subscript> -> (<BinOp> -> ())))'])
+
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_type_alias_access_03(self):
+        code = """class Outer[A]:\n def inner[B](self):\n  type TA1[C] = TA1[A, B] | int; return TA1"""
+        self.checkChains(code, ['Outer -> ()'])
+
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_scopes01(self):
+        code = """\
+from typing import Sequence
+
+# The following generates no compiler error, but a type checker
+# should generate an error because an upper bound type must be concrete,
+# and ``Sequence[S]`` is generic. Future extensions to the type system may
+# eliminate this limitation.
+class ClassA[S, T: Sequence[S]]: ...
+
+# The following generates no compiler error, because the bound for ``S``
+# is lazily evaluated. However, type checkers should generate an error.
+class ClassB[S: Sequence[T], T]: ...
+"""
+        node, du = self.checkChains(code, ['Sequence -> (Sequence -> (<Subscript> -> ()), Sequence -> (<Subscript> -> ()))',
+                                'ClassA -> ()',
+                                'ClassB -> ()'])
+        assert du.dump_chains(TypeParamScope(node.body[1])) == ['S -> (S -> (<Subscript> -> ()))', 'T -> ()']
+        assert du.dump_chains(TypeParamScope(node.body[2])) == ['S -> ()', 'T -> (T -> (<Subscript> -> ()))']
+
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_scopes02(self):
+        code = """\
+from x import BaseClass, dec, Foo
+
+class ClassA[T](BaseClass[T], param = Foo[T]): ...  # OK
+
+print(T)  # Runtime error: 'T' is not defined
+
+@dec(Foo[T])  # Runtime error: 'T' is not defined
+class ClassA[T]: ...
+"""
+        self.check_message(code, ["W: unbound identifier 'T' at <unknown>:5:6", 
+                                  "W: unbound identifier 'T' at <unknown>:7:9"])
+
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_scopes03(self):
+        code = """\
+from x import dec
+def func1[T](a: T) -> T: ...  # OK
+
+print(T)  # Runtime error: 'T' is not defined
+
+def func2[T](a = list[T]): ...  # Runtime error: 'T' is not defined
+
+@dec(list[T])  # Runtime error: 'T' is not defined
+def func3[T](): ...
+"""
+        self.check_message(code, ["W: unbound identifier 'T' at <unknown>:4:6", 
+                                  "W: unbound identifier 'T' at <unknown>:6:22", 
+                                  "W: unbound identifier 'T' at <unknown>:8:10"])
+    
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_scopes04(self):
+
+        code = """\
+S = 0
+
+def outer1[S]():
+    S = 1
+    T = 1
+
+    def outer2[T]():
+
+        def inner1():
+            nonlocal S  # OK because it binds variable S from outer1
+            print(S)
+            nonlocal T  # Syntax error: nonlocal binding not allowed for type parameter
+            print(T)
+
+        def inner2():
+            global S  # OK because it binds variable S from global scope
+            print(S)
+"""
+        self.check_message(code,  ['W: names defined in annotation scopes cannot be rebound with nonlocal statements at <unknown>:12:12'])
+        node, du = self.checkChains(code, ['S -> (S -> (<Call> -> ()))', 'outer1 -> ()'], strict=False)
+        # assert
+        
+
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_scopes04bis(self):
+        code = '''\
+def outer1():
+    def outer2[T]():
+        def inner1():
+            print(T)
+        inner1()
+    outer2()
+outer1()
+'''
+        self.check_message(code, [])
+
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_scopes05(self):
+        code = """\
+from typing import Sequence
+
+class Outer:
+    class Private:
+        pass
+
+    # If the type parameter scope was like a traditional function/method scope,
+    # the base class 'Private' would not be accessible here.
+    class Inner[T](Private, Sequence[T]):
+        pass
+
+    # Likewise, 'Inner' would not be available in these type annotations.
+    def method1[T](self, a: Inner[T]) -> Inner[T]:
+        return a
+"""
+        node, du = self.checkChains(code, [('Sequence -> ('
+                                                'Sequence -> ('
+                                                    '<Subscript> -> ('
+                                                        'Inner -> ('
+                                                            'Inner -> ('
+                                                                '<Subscript> -> ()'
+                                                            '), '
+                                                            'Inner -> ('
+                                                                '<Subscript> -> ()'
+                                                            ')'
+                                                        ')'
+                                                    ')'
+                                                ')'
+                                            ')'), 
+                                            'Outer -> ()'])
+        Outer = next(iter(d for d in du.locals[node] if d.name() == 'Outer'))
+        assert du.dump_chains(Outer.node) == ['Private -> (Private -> (Inner -> (Inner -> (<Subscript> -> ()), Inner -> (<Subscript> -> ()))))', 
+                                              'Inner -> (Inner -> (<Subscript> -> ()), Inner -> (<Subscript> -> ()))', 
+                                              'method1 -> ()']
+
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_scopes06(self):
+        code = """\
+from typing import Sequence
+from x import decorator
+
+T = 0
+
+@decorator(T)  # Argument expression `T` evaluates to 0
+class ClassA[T](Sequence[T]):
+    T = 1
+
+    # All methods below should result in a type checker error
+    # "type parameter 'T' already in use" because they are using the
+    # type parameter 'T', which is already in use by the outer scope
+    # 'ClassA'.
+    def method1[T](self):
+        ...
+
+    def method2[T](self, x = T):  # Parameter 'x' gets default value of 1
+        ...
+
+    def method3[T](self, x: T):  # Parameter 'x' has type T (scoped to method3)
+        ...
+
+"""
+        node, du = self.checkChains(code, ['Sequence -> (Sequence -> (<Subscript> -> (ClassA -> ())))',
+                                'decorator -> (decorator -> (<Call> -> (ClassA -> ())))',
+                                'T -> (T -> (<Call> -> (ClassA -> ())))',
+                                'ClassA -> ()'])
+        ClassA = next(iter(d for d in du.locals[node] if d.name() == 'ClassA'))
+        assert du.dump_chains(TypeParamScope(ClassA.node)) == ['T -> (T -> (<Subscript> -> (ClassA -> ())))']
+        assert du.dump_chains(ClassA.node) == ['T -> (T -> (method2 -> ()))', 
+                                               'method1 -> ()', 
+                                               'method2 -> ()', 
+                                               'method3 -> ()']
+       
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_scopes07(self):
+        code = """\
+T = 0
+
+# T refers to the global variable
+print(T)  # Prints 0
+
+class Outer[T]:
+    T = 1
+
+    # T refers to the local variable scoped to class 'Outer'
+    print(T)  # Prints 1
+
+    class Inner1:
+        T = 2
+
+        # T refers to the local type variable within 'Inner1'
+        print(T)  # Prints 2
+
+        def inner_method(self):
+            # T refers to the type parameter scoped to class 'Outer';
+            # If 'Outer' did not use the new type parameter syntax,
+            # this would instead refer to the global variable 'T'
+            print(T)  # Prints 'T'
+
+    def outer_method(self):
+        T = 3
+
+        # T refers to the local variable within 'outer_method'
+        print(T)  # Prints 3
+
+        def inner_func():
+            # T refers to the variable captured from 'outer_method'
+            print(T)  # Prints 3
+"""
+        node, du = self.checkChains(code,  ['T -> (T -> (<Call> -> ()))', 'Outer -> ()'])
+        
+        assert [d.name() for d in du.locals[node]] == ['T', 'Outer']
+
+        Outer = next(iter(d for d in du.locals[node] if d.name() == 'Outer'))
+        Inner1 = next(iter(d for d in du.locals[Outer.node] if d.name() == 'Inner1'))
+        inner_method = next(iter(d for d in du.locals[Inner1.node] if d.name() == 'inner_method'))
+        outer_method = next(iter(d for d in du.locals[Outer.node] if d.name() == 'outer_method'))
+
+        assert du.dump_chains(inner_method.node) == ['self -> ()',]
+        assert du.dump_chains(Inner1.node) == ['T -> (T -> (<Call> -> ()))', 'inner_method -> ()',]
+        assert du.dump_chains(outer_method.node) == ['self -> ()',
+                                                     'T -> (T -> (<Call> -> ()), T -> (<Call> -> ()))',
+                                                     'inner_func -> ()',]
+
+    
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_scopes08(self):
+        code = '''\
+from x import decorator
+T = 1
+@decorator
+def f[decorator, T: int, U: (int, str), *Ts, **P](
+    y: U,
+    x: T = T, # default values are evaluated outside the TypeParamScope scope
+    *args: *Ts,
+    **kwargs: P.kwargs,
+) -> T:
+    return x
+'''
+        node, du = self.checkChains(code,  ['decorator -> (decorator -> ())', 
+                                 'T -> (T -> (f -> ()))', 
+                                 'f -> ()'])
+        assert du.dump_chains(TypeParamScope(node.body[-1])) == [
+            'decorator -> ()', 'T -> (T -> (), T -> ())', 
+            'U -> (U -> ())', 'Ts -> (Ts -> (<Starred> -> ()))', 
+            'P -> (P -> (.kwargs -> ()))']
+        assert du.dump_chains(node.body[-1]) == ['y -> ()', 'x -> (x -> ())', 
+                                                 'args -> ()', 'kwargs -> ()']
+        
+            
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_scopes09(self):
+        code = '''\
+from x import decorator
+@decorator
+class B[decorator](object):
+    print(decorator)
+'''
+        self.checkChains(code,  ['decorator -> (decorator -> (B -> ()))', 
+                                 'B -> ()'])
+    
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_scopes10(self):
+        code = '''\
+class C[V]:
+    class D:
+        class E:
+            a: V'''
+        node, du = self.checkChains(code,  ['C -> ()'])
+        C = next(iter(d for d in du.locals[node] if d.name() == 'C'))
+        assert TypeParamScope(C.node) in du.locals
+        assert du.dump_chains(TypeParamScope(C.node)) == ['V -> (V -> ())']
+
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_gen_exp_in_nested_class(self):
+        # from https://github.com/python/cpython/pull/109196/files
+        code = """
+        from test.test_type_params import make_base
+        class C[T]:
+            T = "class"
+            class Inner(make_base(T for _ in (1,)), make_base(T)):
+                pass
+        """
+        self.checkChains(code, ['make_base -> (make_base -> (<Call> -> (Inner -> ())), make_base -> (<Call> -> (Inner -> ())))', 'C -> ()'])
+    
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_listcomp_in_nested_class(self):
+        code = """
+            from test.test_type_params import make_base
+            class C[T]:
+                T = "class"
+                class Inner(make_base([T for _ in (1,)]), make_base(T)):
+                    pass
+        """
+        self.checkChains(code, ['make_base -> (make_base -> (<Call> -> (Inner -> ())), make_base -> (<Call> -> (Inner -> ())))', 'C -> ()'])
+
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_gen_exp_in_nested_generic_class(self):
+        code = """
+            from test.test_type_params import make_base
+            class C[T]:
+                T = "class"
+                class Inner[U](make_base(T for _ in (1,)), make_base(T)):
+                    pass
+        """
+        self.check_message(code, [])
+        self.checkChains(code, ['make_base -> (make_base -> (<Call> -> (Inner -> ())), make_base -> (<Call> -> (Inner -> ())))', 'C -> ()'])
+    
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_listcomp_in_nested_generic_class(self):
+        code = """
+        from test.test_type_params import make_base
+        class C[T]:
+            T = "class"
+            class Inner[U](make_base([T for _ in (1,)]), make_base(T)):
+                pass
+        """
+        self.check_message(code, [])
+        self.checkChains(code, ['make_base -> (make_base -> (<Call> -> (Inner -> ())), make_base -> (<Call> -> (Inner -> ())))', 'C -> ()'])
+
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_gen_exp_in_generic_method(self):
+        code = """
+            class C[T]:
+                T = "class"
+                def meth[U](x: (T for _ in (1,)), y: T):
+                    pass
+        """
+        self.check_message(code, [])
+        self.checkChains(code, ['C -> ()'])
+
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_nested_scope_in_generic_alias(self):
+        code = """
+            class C[T]:
+                T = "class"
+                {}
+        """
+        error_cases = [
+            "type Alias1[T] = lambda: T",
+            "type Alias2 = lambda: T",
+            "type Alias3[T] = (T for _ in (1,))",
+            "type Alias4 = (T for _ in (1,))",
+            "type Alias5[T] = [T for _ in (1,)]",
+            "type Alias6 = [T for _ in (1,)]",
+        ]
+        for case in error_cases:
+            with self.subTest(case=case):
+                self.check_message(code.format(case), [])
+    
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_pep695_later_defined_typevar_reference(self):
+        cases = [
+            'class o[T:(S,),S]:...',
+            'def o[T:(S,),S]():...',
+            'type o[T:(S,),S]=...', ]
+
+        for code in cases:
+            with self.subTest(code):
+                self.checkChains(code, ['o -> ()'])
+        
+        for code in cases:
+            code = 'S = 1\n' + code
+            with self.subTest(code):
+                self.checkChains(code, ['S -> ()', 'o -> ()'])
+    
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")  
+    def test_pepe695_class_keywords(self):
+        src = '''
+        class A[T]:
+            ...
+        class Bag[T](A[T], metaclass=T): ...'''
+        self.check_message(src, [])
+    
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")  
+    def test_pepe695_annotations_before_python_314(self):
+        src = '''def f[T](a:(b:=True)): ...'''
+        
+        # Python 3.12
+        self.check_message(src, [])
+
+        # Python 3.14
+        self.check_message('from __future__ import annotations\n' + src, 
+                           ['W: assignment expression cannot be used in annotation-like scopes at <unknown>:2:12'])
+
+    @skipIf(sys.version_info < (3,13), "Python 3.13 syntax")  
+    def test_pep696_type_aliases_default_forward_reference(self):
+        code = '''type X[T = defer] = ...; defer = X'''
+        self.check_message(code, [])
 
     @skipIf(sys.version_info < (3,10), "Python 3.10 syntax")
     def test_match_value(self):
@@ -1691,10 +2263,12 @@ def normalize_usedef_chains(self):
 
 class TestUseDefChains(TestCase):
     ast = _gast
-    def checkChains(self, code, ref):
+    
+    def checkChains(self, code, ref, strict=True):
         node = self.ast.parse(code)
-
-        c = StrictDefUseChains()
+        
+        c = StrictDefUseChains() if strict else beniget.DefUseChains()
+        
         c.visit(node)
         cc = beniget.UseDefChains(c)
         actual = normalize_usedef_chains(cc)
@@ -1720,6 +2294,38 @@ class TestUseDefChains(TestCase):
         code = "a = 1; del a"
         self.checkChains(code, "a <- {a}")
     
+    @skipIf(sys.version_info < (3,13), "Python 3.13 syntax")  
+    def test_pep696_type_aliases(self):
+        code = '''type X[T = bytes] = dict[T, int]'''
+        self.checkChains(code, '<Subscript> <- {<Tuple>, dict}, '
+                               '<Tuple> <- {T, int}, '
+                               'T <- {T}, bytes <- {<type>}, '
+                               'dict <- {<type>}, int <- {<type>}')
+    
+    @skipIf(sys.version_info < (3,13), "Python 3.13 syntax")  
+    def test_pepe696_function_type_param(self):
+        code = '''def foo[T = bytes, *Ts = *tuple[str, int], **P = [str, int]](*args: *Ts, **kwargs: P.kwargs) -> T: ...'''
+        self.checkChains(code, '.kwargs <- {P}, <List> <- {int, str}, '
+                               '<Starred> <- {<Subscript>}, '
+                               '<Starred> <- {Ts}, <Subscript> <- {<Tuple>, tuple}, '
+                               '<Tuple> <- {int, str}, P <- {P}, T <- {T}, '
+                               'Ts <- {Ts}, bytes <- {<type>}, int <- {<type>}, '
+                               'int <- {<type>}, str <- {<type>}, '
+                               'str <- {<type>}, tuple <- {<type>}')
+    
+    @skipIf(sys.version_info < (3,13), "Python 3.13 syntax")  
+    def test_pep696_class_paramspec(self):
+        code = '''class Foo[**P = [str, int]]: ...'''
+        self.checkChains(code, '<List> <- {int, str}, int <- {<type>}, str <- {<type>}')
+
+    @skipIf(sys.version_info < (3,13), "Python 3.13 syntax")  
+    def test_pepe696_class_typevar_tuple(self):
+        code = '''class Foo[*Ts = *tuple[str, int]]: ...'''
+        self.checkChains(code, '<Starred> <- {<Subscript>}, '
+                               '<Subscript> <- {<Tuple>, tuple}, '
+                               '<Tuple> <- {int, str}, '
+                               'int <- {<type>}, str <- {<type>}, tuple <- {<type>}')
+
     def test_fstring(self):
         code = "v = 3.6; f'f-strings are new in Python {v}!'"
         self.checkChains(code, '<FormattedValue> <- {v}, '
@@ -1735,4 +2341,84 @@ class TestUseDefChains(TestCase):
 
 class TestUseDefChainsStdlib(TestUseDefChains):
     ast = _ast
+        
+class TestCollecLocals(TestCase):
+    ast = _gast
 
+    def test_module_locals(self):
+        src = 'class A:...  \ndef b(): ...  \nvar = True   \nfrom x import y as e   \nimport ast   \nimport concurrent.futures'
+        node = self.ast.parse(src)
+        assert collect_locals(node) == {'A', 'b', 'var', 'e', 'ast', 'concurrent'}
+
+    def test_class_locals(self):
+        src = 'class A:\n    x = 1\n    def foo(self): pass\n    def bar(self): pass'
+        node = self.ast.parse(src)
+        assert collect_locals(node.body[0]) == {'x', 'foo', 'bar'}
+
+    def test_function_locals(self):
+        src = 'def f():\n    x = 1\n    y = 2\n    return x + y'
+        node = self.ast.parse(src)
+        assert collect_locals(node.body[0]) == {'x', 'y'}
+
+    def test_function_parameters(self):
+        src = 'def f(a, b, *, c, **kwargs): pass'
+        node = self.ast.parse(src)
+        # TODO: Is it normal that parameters are not included in locals?
+        assert collect_locals(node.body[0]) == set()
+
+    @skipIf(sys.version_info < (3,9), "Python 3.9 syntax")
+    def test_warlus_operator(self):
+        src = 'def f():\n    if (x := 1):\n        pass'
+        node = self.ast.parse(src)
+        assert collect_locals(node.body[0]) == {'x'}
+
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_class_type_parameters(self):
+        src = 'class A[T, U]: v = 1'
+        cls = self.ast.parse(src).body[0]
+        assert collect_locals(cls) == {'v'}
+        assert collect_locals(TypeParamScope(cls)) == {'A', 'T', 'U'}
+
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_function_type_parameters(self):
+        src = 'def f[T, U](): v = 1'
+        cls = self.ast.parse(src).body[0]
+        assert collect_locals(cls) == {'v'}
+        assert collect_locals(TypeParamScope(cls)) == {'f', 'T', 'U'}
+
+    def test_comprehensions(self):
+        src = '[x for x in range(10)]'
+        node = self.ast.parse(src)
+        comp = node.body[0].value
+        assert collect_locals(comp) == {'x'}
+
+class TestCollecLocalsStdlib(TestCollecLocals):
+    ast = _ast
+
+class TestTypeParamScope(TestCase):
+    ast = _gast
+
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_TypeParamScope_equality(self):
+        src = 'class A[T]: ...'
+        node = self.ast.parse(src).body[0]
+
+        assert TypeParamScope(node) == TypeParamScope(node)
+        assert hash(TypeParamScope(node)) == hash(TypeParamScope(node))
+
+        assert TypeParamScope(node) != node
+        assert hash(TypeParamScope(node)) != hash(node)
+
+        assert TypeParamScope(node) is not TypeParamScope(node)
+
+    
+    @skipIf(sys.version_info < (3,12), "Python 3.12 syntax")
+    def test_TypeParamScope_in_locals(self):
+        src = 'class ClassA[T]:\n def func(self, x: T) -> T: ...'
+        node, du = TestDefUseChains.checkChains(self, src, ['ClassA -> ()'])
+
+        assert TypeParamScope(node.body[0]) in du.locals
+        assert du.dump_chains(TypeParamScope(node.body[0])) == ['T -> (T -> (), T -> ())']
+
+class TestTypeParamScopeStdlib(TestTypeParamScope):
+    ast = _ast


### PR DESCRIPTION
* Support PEP695 type parameters

* Add support for PEP696, type parameters defaults as well

* Expose TypeParamScope

Fixes #82

This is somewhat linked to #130 in the sense that enabling Python 3.14-like behaviour can be achieved by setting `DefUseChains.future_annotations` to `True` before visiting the module node.